### PR TITLE
feat: initial packet-stats implementation

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -94,7 +94,7 @@ Usage:
     [--pre-streaming] [<file>]
   mirakc-arib filter-program-metadata [--sid=<sid>] [<file>]
   mirakc-arib record-service --sid=<sid> --file=<file>
-    --chunk-size=<bytes> --num-chunks=<num> [--start-pos=<pos>] [<file>]
+    --chunk-size=<bytes> --num-chunks=<num> [--start-pos=<pos>] [--packet-stats] [<file>]
   mirakc-arib track-airtime --sid=<sid> --eid=<eid> [<file>]
   mirakc-arib seek-start --sid=<sid>
     [--max-duration=<ms>] [--max-packets=<num>] [<file>]
@@ -651,7 +651,7 @@ Record a service stream into a ring buffer file
 
 Usage:
   mirakc-arib record-service --sid=<sid> --file=<file>
-    --chunk-size=<bytes> --num-chunks=<num> [--start-pos=<pos>] [<file>]
+    --chunk-size=<bytes> --num-chunks=<num> [--start-pos=<pos>] [--packet-stats] [<file>]
 
 Options:
   -h --help
@@ -673,6 +673,9 @@ Options:
   --start-pos=<pos>  [default: 0]
     A file position to start recoring.
     The value must be a multiple of the chunk size.
+  
+  --packet-stats
+    Enables statistics on TS packets.
 
 Arguments:
   <file>
@@ -1243,6 +1246,7 @@ void LoadOption(const Args& args, ServiceRecorderOption* opt) {
   static const std::string kChunkSize = "--chunk-size";
   static const std::string kNumChunks = "--num-chunks";
   static const std::string kStartPos = "--start-pos";
+  static const std::string kPacketStats = "--packet-stats";
 
   opt->sid = static_cast<uint16_t>(args.at(kSid).asLong());
   opt->file = args.at(kFile).asString();
@@ -1280,9 +1284,13 @@ void LoadOption(const Args& args, ServiceRecorderOption* opt) {
       std::abort();
     }
   }
+  if (args.at(kPacketStats).asBool()) {
+    opt->packet_stats = true;
+  }
   MIRAKC_ARIB_INFO(
-      "ServiceRecorderOptions: sid={:04X} file={} chunk-size={} num-chunks={} start-pos={}",
-      opt->sid, opt->file, opt->chunk_size, opt->num_chunks, opt->start_pos);
+      "ServiceRecorderOptions: sid={:04X} file={} chunk-size={} num-chunks={} start-pos={} "
+      "packet-stats={}",
+      opt->sid, opt->file, opt->chunk_size, opt->num_chunks, opt->start_pos, opt->packet_stats);
 }
 
 void LoadOption(const Args& args, AirtimeTrackerOption* opt) {

--- a/src/packet_stats_collector.hh
+++ b/src/packet_stats_collector.hh
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <string.h>
+#include <array>
+#include <cstdint>
+#include "base.hh"
+
+namespace {
+
+class PacketStatsCollector final {
+ public:
+  PacketStatsCollector() {}
+  ~PacketStatsCollector() {}
+
+  void CollectPacketStats(const ts::TSPacket& packet) {
+    auto pid = packet.getPID();
+    auto last_cc = stats[pid].last_cc;
+    auto cc = packet.getCC();
+    auto has_payload = packet.hasPayload();
+    auto tei = packet.getTEI();
+    stats[pid].last_cc = cc;
+    stats[pid].last_packet = packet;
+
+    if (packet.getScrambling()) {
+      ++scrambled_packets_;
+    }
+
+    auto duplicate_found = false;
+
+    if (packet.getDiscontinuityIndicator() || packet.getPID() == ts::PID_NULL) {
+      // do nothing
+    } else if (tei) {
+      ++error_packets_;
+    } else if (last_cc != ts::INVALID_CC) {
+      if (has_payload) {
+        if (last_cc == cc) {
+          if (stats[pid].last_packet != packet) {
+            // non-duplicate packet
+            ++dropped_packets_;
+          } else {
+            // duplicate packet
+            duplicate_found = true;
+          }
+        } else {
+          // regular packet
+          uint8_t expectedCC = (last_cc + 1) & ts::CC_MASK;
+          if (expectedCC != cc) {
+            ++dropped_packets_;
+          }
+        }
+      } else {
+        // Continuity counter should not increment if packet has no payload
+        if (last_cc != cc) {
+          ++dropped_packets_;
+        }
+      }
+    }
+
+    if (duplicate_found) {
+      // duplicate packet is only allowed once
+      ++stats[pid].duplicate_packets;
+      if (stats[pid].duplicate_packets > 1) {
+        ++dropped_packets_;
+      }
+    } else {
+      stats[pid].duplicate_packets = 0;
+    }
+  }
+
+  void ResetPacketStats() {
+    error_packets_ = 0;
+    dropped_packets_ = 0;
+    scrambled_packets_ = 0;
+  }
+
+  uint64_t GetErrorPackets() const {
+    return error_packets_;
+  }
+
+  uint64_t GetDroppedPackets() const {
+    return dropped_packets_;
+  }
+
+  uint64_t GetScrambledPackets() const {
+    return scrambled_packets_;
+  }
+
+ private:
+  struct PacketStat {
+    uint8_t last_cc = ts::INVALID_CC;
+    uint8_t duplicate_packets = 0;
+    ts::TSPacket last_packet;
+  };
+
+  MIRAKC_ARIB_NON_COPYABLE(PacketStatsCollector);
+  std::array<PacketStat, ts::PID_MAX> stats;
+  uint64_t error_packets_ = 0;
+  uint64_t dropped_packets_ = 0;
+  uint64_t scrambled_packets_ = 0;
+};
+
+}  // namespace

--- a/src/service_recorder.hh
+++ b/src/service_recorder.hh
@@ -29,6 +29,7 @@
 #include "jsonl_source.hh"
 #include "logging.hh"
 #include "packet_sink.hh"
+#include "packet_stats_collector.hh"
 #include "tsduck_helper.hh"
 
 #define MIRAKC_ARIB_SERVICE_RECORDER_TRACE(...) MIRAKC_ARIB_TRACE("service-recorder: " __VA_ARGS__)
@@ -45,6 +46,7 @@ struct ServiceRecorderOption final {
   size_t chunk_size = 0;
   size_t num_chunks = 0;
   uint64_t start_pos = 0;
+  bool packet_stats = false;
 };
 
 class ServiceRecorderTestAccessor;
@@ -112,6 +114,10 @@ class ServiceRecorder final : public PacketSink,
 
     demux_.feedPacket(packet);
 
+    if (option_.packet_stats) {
+      packet_stats_collector_.CollectPacketStats(packet);
+    }
+
     switch (state_) {
       case State::kPreparing:
         return OnPreparing(packet);
@@ -140,6 +146,7 @@ class ServiceRecorder final : public PacketSink,
     // internal consistency even if no TV program starts.  In this case, the end
     // time of the record for the last TV program (held by `eit_`) is extended.
     SendEventUpdateMessage(eit_, now, pos);
+    SendPacketStatsMessage();
     SendChunkMessage(now, pos);
   }
 
@@ -326,8 +333,7 @@ class ServiceRecorder final : public PacketSink,
       if (event_changed) {
         MIRAKC_ARIB_SERVICE_RECORDER_WARN("Event#{:04X} has started before Event#{:04X} ends",
             GetEvent(new_eit).event_id, GetEvent(eit).event_id);
-        UpdateEventBoundary(now, sink_->pos());
-        SendEventEndMessage(eit);
+        HandleEventEnd(now, eit);
         SendEventStartMessage(new_eit);
       } else {
         if (IsUnspecifiedEventEndTime(GetEvent(eit))) {
@@ -335,8 +341,7 @@ class ServiceRecorder final : public PacketSink,
         } else {
           auto end_time = GetEventEndTime(GetEvent(eit));
           if (now >= end_time) {
-            UpdateEventBoundary(end_time, sink_->pos());
-            SendEventEndMessage(eit);
+            HandleEventEnd(end_time, eit);
             event_started_ = false;  // wait for new event
           }
         }
@@ -354,6 +359,12 @@ class ServiceRecorder final : public PacketSink,
     MIRAKC_ARIB_SERVICE_RECORDER_DEBUG("Update event boundary with {}@{}", time, pos);
     event_boundary_time_ = time;
     event_boundary_pos_ = pos;
+  }
+
+  void HandleEventEnd(const ts::Time& endTime, const std::shared_ptr<ts::EIT>& eit) {
+    UpdateEventBoundary(endTime, sink_->pos());
+    SendPacketStatsMessage();
+    SendEventEndMessage(eit);
   }
 
   void SendStartMessage() {
@@ -426,6 +437,32 @@ class ServiceRecorder final : public PacketSink,
     SendEventMessage("event-end", eit, event_boundary_time_, event_boundary_pos_);
   }
 
+  void SendPacketStatsMessage() {
+    if (!option_.packet_stats) {
+      return;
+    }
+
+    auto error_packets = packet_stats_collector_.GetErrorPackets();
+    auto dropped_packets = packet_stats_collector_.GetDroppedPackets();
+    auto scrambled_packets = packet_stats_collector_.GetScrambledPackets();
+    MIRAKC_ARIB_SERVICE_RECORDER_INFO("PacketStats: Error: {}, Dropped {}, Scrambled: {}",
+        error_packets, dropped_packets, scrambled_packets);
+
+    rapidjson::Document doc(rapidjson::kObjectType);
+    auto& allocator = doc.GetAllocator();
+
+    rapidjson::Value data(rapidjson::kObjectType);
+    data.AddMember("errorPackets", error_packets, allocator);
+    data.AddMember("droppedPackets", dropped_packets, allocator);
+    data.AddMember("scrambledPackets", scrambled_packets, allocator);
+
+    doc.AddMember("type", "packet-stats", allocator);
+    doc.AddMember("data", data, allocator);
+
+    FeedDocument(doc);
+    packet_stats_collector_.ResetPacketStats();
+  }
+
   void SendEventMessage(const std::string& type, const std::shared_ptr<ts::EIT>& eit,
       const ts::Time& time, uint64_t pos) {
     MIRAKC_ARIB_ASSERT(eit);
@@ -480,6 +517,7 @@ class ServiceRecorder final : public PacketSink,
   ts::PID pmt_pid_ = ts::PID_NULL;
   State state_ = State::kPreparing;
   bool event_started_ = false;
+  PacketStatsCollector packet_stats_collector_;
 
   friend class ServiceRecorderTestAccessor;
 

--- a/test/cli_tests.sh
+++ b/test/cli_tests.sh
@@ -89,6 +89,7 @@ assert 0 "$MIRAKC_ARIB filter-program-metadata --sid=0xFFFF"
 assert 0 "$MIRAKC_ARIB record-service --sid=1 --file=$TMPFILE --chunk-size=8192 --num-chunks=1"
 assert 0 "$MIRAKC_ARIB record-service --sid=1 --file=$TMPFILE --chunk-size=8192 --num-chunks=1 --start-pos=0"
 assert 0 "$MIRAKC_ARIB record-service --sid=1 --file=$TMPFILE --chunk-size=8192 --num-chunks=2 --start-pos=8192"
+assert 0 "$MIRAKC_ARIB record-service --sid=1 --file=$TMPFILE --chunk-size=8192 --num-chunks=2 --packet-stats"
 if [ -z "$CI" ]
 then
   # This test fails in GitHub Actions.

--- a/test/service_recorder_test.cc
+++ b/test/service_recorder_test.cc
@@ -41,6 +41,8 @@ class ServiceRecorderTestAccessor final {
     return recorder.clock_.IsReady();
   }
 };
+
+struct ServiceRecorderTest : testing::TestWithParam<ServiceRecorderOption> {};
 }  // namespace
 
 TEST(ServiceRecorderTest, NoPacket) {
@@ -191,8 +193,8 @@ TEST(ServiceRecorderTest, EventStart) {
   EXPECT_TRUE(src.IsEmpty());
 }
 
-TEST(ServiceRecorderTest, EventProgress) {
-  ServiceRecorderOption option = kOption;
+TEST_P(ServiceRecorderTest, EventProgress) {
+  ServiceRecorderOption option = GetParam();
 
   TableSource src;
   auto ring_sink = std::make_unique<MockRingSink>(option.chunk_size, option.num_chunks);
@@ -281,6 +283,18 @@ TEST(ServiceRecorderTest, EventProgress) {
           MockJsonlSink::Stringify(doc));
       return true;
     });
+    if (option.packet_stats) {
+      EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+        EXPECT_EQ(R"({"type":"packet-stats","data":{)"
+                  R"("errorPackets":0,)"
+                  R"("droppedPackets":0,)"
+                  R"("scrambledPackets":0)"
+                  R"(})"
+                  R"(})",
+            MockJsonlSink::Stringify(doc));
+        return true;
+      });
+    }
     EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
       EXPECT_EQ(R"({"type":"chunk","data":{"chunk":{)"
                 R"("timestamp":1609426800000,"pos":16384)"
@@ -308,6 +322,18 @@ TEST(ServiceRecorderTest, EventProgress) {
           MockJsonlSink::Stringify(doc));
       return true;
     });
+    if (option.packet_stats) {
+      EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+        EXPECT_EQ(R"({"type":"packet-stats","data":{)"
+                  R"("errorPackets":0,)"
+                  R"("droppedPackets":0,)"
+                  R"("scrambledPackets":0)"
+                  R"(})"
+                  R"(})",
+            MockJsonlSink::Stringify(doc));
+        return true;
+      });
+    }
     EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
       EXPECT_EQ(R"({"type":"chunk","data":{"chunk":{)"
                 R"("timestamp":1609426800000,"pos":0)"
@@ -322,7 +348,7 @@ TEST(ServiceRecorderTest, EventProgress) {
     EXPECT_CALL(*ring_sink, End).WillOnce(testing::Return());
   }
 
-  auto recorder = std::make_unique<ServiceRecorder>(kOption);
+  auto recorder = std::make_unique<ServiceRecorder>(option);
   recorder->ServiceRecorder::Connect(std::move(ring_sink));
   recorder->JsonlSource::Connect(std::move(json_sink));
   src.Connect(std::move(recorder));
@@ -330,8 +356,8 @@ TEST(ServiceRecorderTest, EventProgress) {
   EXPECT_TRUE(src.IsEmpty());
 }
 
-TEST(ServiceRecorderTest, EventEnd) {
-  ServiceRecorderOption option = kOption;
+TEST_P(ServiceRecorderTest, EventEnd) {
+  ServiceRecorderOption option = GetParam();
 
   TableSource src;
   auto ring_sink = std::make_unique<MockRingSink>(option.chunk_size, option.num_chunks);
@@ -409,6 +435,18 @@ TEST(ServiceRecorderTest, EventEnd) {
           MockJsonlSink::Stringify(doc));
       return true;
     });
+    if (option.packet_stats) {
+      EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+        EXPECT_EQ(R"({"type":"packet-stats","data":{)"
+                  R"("errorPackets":0,)"
+                  R"("droppedPackets":1,)"
+                  R"("scrambledPackets":0)"
+                  R"(})"
+                  R"(})",
+            MockJsonlSink::Stringify(doc));
+        return true;
+      });
+    }
     EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
       EXPECT_EQ(R"({"type":"event-end","data":{)"
                 R"("originalNetworkId":1,)"
@@ -456,13 +494,13 @@ TEST(ServiceRecorderTest, EventEnd) {
     EXPECT_CALL(*ring_sink, End).WillOnce(testing::Return());
   }
 
-  auto recorder = std::make_unique<ServiceRecorder>(kOption);
+  auto recorder = std::make_unique<ServiceRecorder>(option);
   recorder->ServiceRecorder::Connect(std::move(ring_sink));
   recorder->JsonlSource::Connect(std::move(json_sink));
   src.Connect(std::move(recorder));
   EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
   EXPECT_TRUE(src.IsEmpty());
-}
+};
 
 TEST(ServiceRecorderTest, EventStartBeforeEventEnd) {
   ServiceRecorderOption option = kOption;
@@ -991,3 +1029,7 @@ TEST(ServiceRecorderTest, EndOfChunkBeforeNextEvent) {
   EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
   EXPECT_TRUE(src.IsEmpty());
 }
+
+INSTANTIATE_TEST_SUITE_P(EventTestWithPacketStats, ServiceRecorderTest,
+    testing::Values(ServiceRecorderOption{"/dev/null", 3, kChunkSize, kNumChunks, 0, false},
+        ServiceRecorderOption{"/dev/null", 3, kChunkSize, kNumChunks, 0, true}));


### PR DESCRIPTION
タイムシフト録画機能向けのドロップ数統計を追加します。

`mirakc-arib record-service` に新しいオプション`--packet-stats`を追加します。
このオプションが渡された場合のみ以下のような形式でTSパケットの統計を収集して
JSONメッセージとして出力します。

```json5
{
  "type": "packet-stats",
  "data": {
    "errorPackets": 0, // Transport Error Indicatorが1のパケット数
    "droppedPackets": 1, // ドロップしたパケット数
    "scrambledPackets": 0 // Scrambling controlが1のパケット数
  }
}
```

mirakc側でチャンネル毎、番組毎にこの値を加算して
ドロップ数の増加など、録画時の問題の把握に役立てる事が出来ます。

メッセージが出力される度に値が加算される仕組みで、番組毎の統計は現在の番組の値のみが増加しますが、チャンネル毎の統計は永久に増加し続けます。

番組毎の統計については、curlなどのツールでTimeshftのAPIエンドポイントにアクセスし、値を見るだけでドロップ数の把握が出来るようになります。
チャンネル毎の統計については、値を見るだけでは役に立たないですが、Prometheusのような外部の監視ツールから定期取得する事で、増加のあった時刻を知る事ができます。

関連Issue: https://github.com/mirakc/mirakc/issues/15
