### PR TITLE
fix(service-filter): reject unsafe PIDs in dynamically built filters

### DIFF
--- a/src/service_filter.hh
+++ b/src/service_filter.hh
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstdlib>
 #include <memory>
 #include <optional>
@@ -43,6 +44,8 @@ struct ServiceFilterOption final {
   uint16_t sid = 0;
   std::optional<ts::Time> time_limit = std::nullopt;  // JST
 };
+
+class ServiceFilterTestAccessor;
 
 class ServiceFilter final : public PacketSink, public ts::TableHandlerInterface {
  public:
@@ -132,6 +135,37 @@ class ServiceFilter final : public PacketSink, public ts::TableHandlerInterface 
     return true;
   }
 
+  static constexpr std::array<ts::PID, 9> kReservedPsiPids = {
+      ts::PID_PAT,
+      ts::PID_CAT,
+      ts::PID_NIT,
+      ts::PID_SDT,
+      ts::PID_EIT,
+      ts::PID_RST,
+      ts::PID_TOT,
+      ts::PID_BIT,
+      ts::PID_CDT,
+  };
+
+  static bool IsSafeDynamicPid(ts::PID pid) {
+    // Returns true if this dynamic PID is safe to add to a filter set.
+    // PID_NULL must never reach the downstream sink.
+    if (pid == ts::PID_NULL) {
+      return false;
+    }
+
+    // Reserved PSI/SI PIDs are already registered in psi_filter_, so re-adding them to a
+    // dynamic filter set is redundant.  (Rejecting them here also keeps a reserved PID from
+    // ever becoming pmt_pid_, which would corrupt demux_ on the next removePID.)
+    for (auto reserved_pid : kReservedPsiPids) {
+      if (pid == reserved_pid) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   void handleTable(ts::SectionDemux&, const ts::BinaryTable& table) override {
     switch (table.tableId()) {
       case ts::TID_PAT:
@@ -169,17 +203,24 @@ class ServiceFilter final : public PacketSink, public ts::TableHandlerInterface 
       return;
     }
 
-    if (pat.pmts.find(option_.sid) == pat.pmts.end()) {
+    auto new_pmt_it = pat.pmts.find(option_.sid);
+
+    if (new_pmt_it == pat.pmts.end()) {
       MIRAKC_ARIB_SERVICE_FILTER_ERROR("SID#{:04X} not found in PAT", option_.sid);
       done_ = true;
       error_ = true;
       return;
     }
 
+    auto new_pmt_pid = new_pmt_it->second;
+
+    if (!IsSafeDynamicPid(new_pmt_pid)) {
+      MIRAKC_ARIB_SERVICE_FILTER_WARN("Unsafe PMT PID#{:04X}, skip", new_pmt_pid);
+      return;
+    }
+
     psi_filter_.clear();
     MIRAKC_ARIB_SERVICE_FILTER_DEBUG("Clear PSI/SI filter");
-
-    auto new_pmt_pid = pat.pmts[option_.sid];
 
     if (pmt_pid_ != ts::PID_NULL) {
       MIRAKC_ARIB_SERVICE_FILTER_INFO(
@@ -211,15 +252,10 @@ class ServiceFilter final : public PacketSink, public ts::TableHandlerInterface 
     pat_packetizer_.removeAll();
     pat_packetizer_.addTable(context_, pat);
 
-    psi_filter_.insert(ts::PID_PAT);
-    psi_filter_.insert(ts::PID_CAT);
-    psi_filter_.insert(ts::PID_NIT);
-    psi_filter_.insert(ts::PID_SDT);
-    psi_filter_.insert(ts::PID_EIT);
-    psi_filter_.insert(ts::PID_RST);
-    psi_filter_.insert(ts::PID_TOT);
-    psi_filter_.insert(ts::PID_BIT);
-    psi_filter_.insert(ts::PID_CDT);
+    for (auto pid : kReservedPsiPids) {
+      psi_filter_.insert(pid);
+    }
+
     psi_filter_.insert(pmt_pid_);
     MIRAKC_ARIB_SERVICE_FILTER_DEBUG(
         "PSI/SI filter += PAT CAT NIT SDT EIT RST TOT BIT CDT PMT#{:04X}", pmt_pid_);
@@ -239,8 +275,14 @@ class ServiceFilter final : public PacketSink, public ts::TableHandlerInterface 
     auto i = cat.descs.search(ts::DID_CA);
     while (i < cat.descs.size()) {
       ts::CADescriptor desc(context_, *cat.descs[i]);
-      emm_filter_.insert(desc.ca_pid);
-      MIRAKC_ARIB_SERVICE_FILTER_DEBUG("EMM filter += EMM#{:04X}", desc.ca_pid);
+
+      if (IsSafeDynamicPid(desc.ca_pid)) {
+        emm_filter_.insert(desc.ca_pid);
+        MIRAKC_ARIB_SERVICE_FILTER_DEBUG("EMM filter += EMM#{:04X}", desc.ca_pid);
+      } else {
+        MIRAKC_ARIB_SERVICE_FILTER_WARN("Unsafe EMM PID#{:04X}, skip", desc.ca_pid);
+      }
+
       i = cat.descs.search(ts::DID_CA, i + 1);
     }
   }
@@ -261,19 +303,35 @@ class ServiceFilter final : public PacketSink, public ts::TableHandlerInterface 
     content_filter_.clear();
     MIRAKC_ARIB_SERVICE_FILTER_DEBUG("Clear content filter");
 
-    content_filter_.insert(pmt.pcr_pid);
-    MIRAKC_ARIB_SERVICE_FILTER_DEBUG("Content filter += PCR#{:04X}", pmt.pcr_pid);
+    if (IsSafeDynamicPid(pmt.pcr_pid)) {
+      content_filter_.insert(pmt.pcr_pid);
+      MIRAKC_ARIB_SERVICE_FILTER_DEBUG("Content filter += PCR#{:04X}", pmt.pcr_pid);
+    } else {
+      MIRAKC_ARIB_SERVICE_FILTER_WARN("Unsafe PCR PID#{:04X}, skip", pmt.pcr_pid);
+    }
 
     auto i = pmt.descs.search(ts::DID_CA);
     while (i < pmt.descs.size()) {
       ts::CADescriptor desc(context_, *pmt.descs[i]);
-      content_filter_.insert(desc.ca_pid);
-      MIRAKC_ARIB_SERVICE_FILTER_DEBUG("Content filter += ECM#{:04X}", desc.ca_pid);
+
+      if (IsSafeDynamicPid(desc.ca_pid)) {
+        content_filter_.insert(desc.ca_pid);
+        MIRAKC_ARIB_SERVICE_FILTER_DEBUG("Content filter += ECM#{:04X}", desc.ca_pid);
+      } else {
+        MIRAKC_ARIB_SERVICE_FILTER_WARN("Unsafe ECM PID#{:04X}, skip", desc.ca_pid);
+      }
+
       i = pmt.descs.search(ts::DID_CA, i + 1);
     }
 
     for (auto it = pmt.streams.begin(); it != pmt.streams.end(); ++it) {
       ts::PID pid = it->first;
+
+      if (!IsSafeDynamicPid(pid)) {
+        MIRAKC_ARIB_SERVICE_FILTER_WARN("Unsafe stream PID#{:04X}, skip", pid);
+        continue;
+      }
+
       content_filter_.insert(pid);
 
       const auto& stream = it->second;
@@ -325,6 +383,8 @@ class ServiceFilter final : public PacketSink, public ts::TableHandlerInterface 
   ts::PID pmt_pid_ = ts::PID_NULL;
   bool done_ = false;
   bool error_ = false;
+
+  friend class ServiceFilterTestAccessor;
 
   MIRAKC_ARIB_NON_COPYABLE(ServiceFilter);
 };

--- a/test/service_filter_test.cc
+++ b/test/service_filter_test.cc
@@ -17,8 +17,8 @@
 
 #include <cstdlib>
 #include <memory>
+#include <unordered_set>
 
-#include <fmt/format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <tsduck/tsduck.h>
@@ -28,7 +28,277 @@
 #include "test_helper.hh"
 
 namespace {
+
 const ServiceFilterOption kOption{0x0001};
+
+class ServiceFilterTestAccessor final {
+ public:
+  static const std::unordered_set<ts::PID>& ContentFilter(const ServiceFilter& filter) {
+    return filter.content_filter_;
+  }
+
+  static const std::unordered_set<ts::PID>& EmmFilter(const ServiceFilter& filter) {
+    return filter.emm_filter_;
+  }
+
+  static const std::unordered_set<ts::PID>& PsiFilter(const ServiceFilter& filter) {
+    return filter.psi_filter_;
+  }
+
+  static bool IsSafeDynamicPid(ts::PID pid) {
+    return ServiceFilter::IsSafeDynamicPid(pid);
+  }
+
+  static const ts::SectionDemux& Demux(const ServiceFilter& filter) {
+    return filter.demux_;
+  }
+};
+
+}  // namespace
+
+TEST(ServiceFilterTest, IsSafeDynamicPid) {
+  EXPECT_FALSE(ServiceFilterTestAccessor::IsSafeDynamicPid(ts::PID_NULL));
+  EXPECT_FALSE(ServiceFilterTestAccessor::IsSafeDynamicPid(ts::PID_PAT));
+  EXPECT_FALSE(ServiceFilterTestAccessor::IsSafeDynamicPid(ts::PID_CAT));
+  EXPECT_FALSE(ServiceFilterTestAccessor::IsSafeDynamicPid(ts::PID_NIT));
+  EXPECT_FALSE(ServiceFilterTestAccessor::IsSafeDynamicPid(ts::PID_SDT));
+  EXPECT_FALSE(ServiceFilterTestAccessor::IsSafeDynamicPid(ts::PID_EIT));
+  EXPECT_FALSE(ServiceFilterTestAccessor::IsSafeDynamicPid(ts::PID_RST));
+  EXPECT_FALSE(ServiceFilterTestAccessor::IsSafeDynamicPid(ts::PID_TOT));
+  EXPECT_FALSE(ServiceFilterTestAccessor::IsSafeDynamicPid(ts::PID_BIT));
+  EXPECT_FALSE(ServiceFilterTestAccessor::IsSafeDynamicPid(ts::PID_CDT));
+
+  EXPECT_TRUE(ServiceFilterTestAccessor::IsSafeDynamicPid(0x0030));
+  EXPECT_TRUE(ServiceFilterTestAccessor::IsSafeDynamicPid(0x1FFE));
+}
+
+TEST(ServiceFilterTest, RejectUnsafePmtPidFromPat) {
+  TableSource src;
+  auto filter = std::make_unique<ServiceFilter>(kOption);
+  auto* filter_ptr = filter.get();
+  auto sink = std::make_unique<MockSink>();
+
+  // The 1st PAT advertises ts::PID_NULL (0x1FFF) as a PMT PID.
+  // The 2nd PAT advertises 0x0101 as a PMT PID.
+  // Only 0x0101 must be added to psi_filter_ and demux_.
+  // ts::PID_NULL must never be added to psi_filter_ or demux_.
+  src.LoadXml(R"(
+    <?xml version="1.0" encoding="utf-8"?>
+    <tsduck>
+      <PAT version="1" current="true" transport_stream_id="0x1234"
+           test-pid="0x0000">
+        <service service_id="0x0001" program_map_PID="0x1FFF" />
+      </PAT>
+      <PAT version="2" current="true" transport_stream_id="0x1234"
+           test-pid="0x0000" test-cc="1">
+        <service service_id="0x0001" program_map_PID="0x0101" />
+      </PAT>
+    </tsduck>
+  )");
+
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*sink, Start).WillOnce(testing::Return(true));
+    EXPECT_CALL(*sink, HandlePacket).WillOnce([](const ts::TSPacket& packet) {
+      EXPECT_EQ(ts::PID_PAT, packet.getPID());
+      return true;
+    });
+    EXPECT_CALL(*sink, End).WillOnce(testing::Return());
+    EXPECT_CALL(*sink, GetExitCode).WillOnce(testing::Return(EXIT_SUCCESS));
+  }
+
+  filter->Connect(std::move(sink));
+  src.Connect(std::move(filter));
+  EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
+
+  EXPECT_THAT(ServiceFilterTestAccessor::PsiFilter(*filter_ptr),
+      testing::UnorderedElementsAre(ts::PID_PAT, ts::PID_CAT, ts::PID_NIT, ts::PID_SDT,
+          ts::PID_EIT, ts::PID_RST, ts::PID_TOT, ts::PID_BIT, ts::PID_CDT, 0x0101));
+
+  // demux_ must retain PIDs added in the constructor and now include the safe PMT PID.
+  EXPECT_TRUE(ServiceFilterTestAccessor::Demux(*filter_ptr).hasPID(ts::PID_PAT));
+  EXPECT_TRUE(ServiceFilterTestAccessor::Demux(*filter_ptr).hasPID(ts::PID_CAT));
+  EXPECT_TRUE(ServiceFilterTestAccessor::Demux(*filter_ptr).hasPID(0x0101));
+  // The unsafe PMT PID must never be added to demux_.
+  EXPECT_FALSE(ServiceFilterTestAccessor::Demux(*filter_ptr).hasPID(ts::PID_NULL));
+}
+
+TEST(ServiceFilterTest, RejectUnsafeEmmPidsFromCatDescriptors) {
+  TableSource src;
+  auto filter = std::make_unique<ServiceFilter>(kOption);
+  auto* filter_ptr = filter.get();
+  auto sink = std::make_unique<MockSink>();
+
+  // This CAT advertises 0x0101 and ts::PID_EIT (0x0012) as CA PIDs.
+  // Only 0x0101 must be added to emm_filter_.
+  // ts::PID_EIT must never be added to emm_filter_.
+  src.LoadXml(R"(
+    <?xml version="1.0" encoding="utf-8"?>
+    <tsduck>
+      <CAT version="1" current="true" test-pid="0x0001">
+        <CA_descriptor CA_system_id="0x0005" CA_PID="0x0101" />
+        <CA_descriptor CA_system_id="0x0005" CA_PID="0x0012" />
+      </CAT>
+    </tsduck>
+  )");
+
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*sink, Start).WillOnce(testing::Return(true));
+    EXPECT_CALL(*sink, End).WillOnce(testing::Return());
+    EXPECT_CALL(*sink, GetExitCode).WillOnce(testing::Return(EXIT_SUCCESS));
+  }
+
+  // Only a CAT is fed, and ServiceFilter consumes it without forwarding,
+  // so no packets reach the sink.
+  EXPECT_CALL(*sink, HandlePacket).Times(0);
+
+  filter->Connect(std::move(sink));
+  src.Connect(std::move(filter));
+  EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
+
+  EXPECT_THAT(
+      ServiceFilterTestAccessor::EmmFilter(*filter_ptr), testing::UnorderedElementsAre(0x0101));
+}
+
+TEST(ServiceFilterTest, RejectUnsafePcrPidFromPmt) {
+  TableSource src;
+  auto filter = std::make_unique<ServiceFilter>(kOption);
+  auto* filter_ptr = filter.get();
+  auto sink = std::make_unique<MockSink>();
+
+  // This PMT advertises ts::PID_NULL (0x1FFF) as a PCR PID and 0x0103 as a stream PID.
+  // Only 0x0103 must be added to content_filter_.
+  // ts::PID_NULL must never be added to content_filter_.
+  src.LoadXml(R"(
+    <?xml version="1.0" encoding="utf-8"?>
+    <tsduck>
+      <PAT version="1" current="true" transport_stream_id="0x1234"
+           test-pid="0x0000">
+        <service service_id="0x0001" program_map_PID="0x0101" />
+      </PAT>
+      <PMT version="1" current="true" service_id="0x0001" PCR_PID="0x1FFF"
+           test-pid="0x0101">
+        <component elementary_PID="0x0103" stream_type="0x02" />
+      </PMT>
+    </tsduck>
+  )");
+
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*sink, Start).WillOnce(testing::Return(true));
+    EXPECT_CALL(*sink, HandlePacket).WillOnce([](const ts::TSPacket& packet) {
+      EXPECT_EQ(ts::PID_PAT, packet.getPID());
+      return true;
+    });
+    EXPECT_CALL(*sink, HandlePacket).WillOnce([](const ts::TSPacket& packet) {
+      EXPECT_EQ(0x0101, packet.getPID());
+      return true;
+    });
+    EXPECT_CALL(*sink, End).WillOnce(testing::Return());
+    EXPECT_CALL(*sink, GetExitCode).WillOnce(testing::Return(EXIT_SUCCESS));
+  }
+
+  filter->Connect(std::move(sink));
+  src.Connect(std::move(filter));
+  EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
+
+  EXPECT_THAT(ServiceFilterTestAccessor::ContentFilter(*filter_ptr),
+      testing::UnorderedElementsAre(0x0103));
+}
+
+TEST(ServiceFilterTest, RejectUnsafeEcmPidsFromPmtDescriptors) {
+  TableSource src;
+  auto filter = std::make_unique<ServiceFilter>(kOption);
+  auto* filter_ptr = filter.get();
+  auto sink = std::make_unique<MockSink>();
+
+  // This PMT advertises 0x0103 and ts::PID_NIT (0x0010) as ECM PIDs.
+  // Only 0x0103 must be added to content_filter_.
+  // ts::PID_NIT must never be added to content_filter_.
+  src.LoadXml(R"(
+    <?xml version="1.0" encoding="utf-8"?>
+    <tsduck>
+      <PAT version="1" current="true" transport_stream_id="0x1234"
+           test-pid="0x0000">
+        <service service_id="0x0001" program_map_PID="0x0101" />
+      </PAT>
+      <PMT version="1" current="true" service_id="0x0001" PCR_PID="0x0102"
+           test-pid="0x0101">
+        <CA_descriptor CA_system_id="0x0005" CA_PID="0x0103" />
+        <CA_descriptor CA_system_id="0x0005" CA_PID="0x0010" />
+      </PMT>
+    </tsduck>
+  )");
+
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*sink, Start).WillOnce(testing::Return(true));
+    EXPECT_CALL(*sink, HandlePacket).WillOnce([](const ts::TSPacket& packet) {
+      EXPECT_EQ(ts::PID_PAT, packet.getPID());
+      return true;
+    });
+    EXPECT_CALL(*sink, HandlePacket).WillOnce([](const ts::TSPacket& packet) {
+      EXPECT_EQ(0x0101, packet.getPID());
+      return true;
+    });
+    EXPECT_CALL(*sink, End).WillOnce(testing::Return());
+    EXPECT_CALL(*sink, GetExitCode).WillOnce(testing::Return(EXIT_SUCCESS));
+  }
+
+  filter->Connect(std::move(sink));
+  src.Connect(std::move(filter));
+  EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
+
+  EXPECT_THAT(ServiceFilterTestAccessor::ContentFilter(*filter_ptr),
+      testing::UnorderedElementsAre(0x0102, 0x0103));
+}
+
+TEST(ServiceFilterTest, RejectUnsafeStreamPidsFromPmtStreams) {
+  TableSource src;
+  auto filter = std::make_unique<ServiceFilter>(kOption);
+  auto* filter_ptr = filter.get();
+  auto sink = std::make_unique<MockSink>();
+
+  // This PMT advertises 0x0103 and ts::PID_NULL (0x1FFF) as stream PIDs.
+  // Only 0x0103 must be added to content_filter_.
+  // ts::PID_NULL must never be added to content_filter_.
+  src.LoadXml(R"(
+    <?xml version="1.0" encoding="utf-8"?>
+    <tsduck>
+      <PAT version="1" current="true" transport_stream_id="0x1234"
+           test-pid="0x0000">
+        <service service_id="0x0001" program_map_PID="0x0101" />
+      </PAT>
+      <PMT version="1" current="true" service_id="0x0001" PCR_PID="0x0102"
+           test-pid="0x0101">
+        <component elementary_PID="0x0103" stream_type="0x02" />
+        <component elementary_PID="0x1FFF" stream_type="0x06" />
+      </PMT>
+    </tsduck>
+  )");
+
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*sink, Start).WillOnce(testing::Return(true));
+    EXPECT_CALL(*sink, HandlePacket).WillOnce([](const ts::TSPacket& packet) {
+      EXPECT_EQ(ts::PID_PAT, packet.getPID());
+      return true;
+    });
+    EXPECT_CALL(*sink, HandlePacket).WillOnce([](const ts::TSPacket& packet) {
+      EXPECT_EQ(0x0101, packet.getPID());
+      return true;
+    });
+    EXPECT_CALL(*sink, End).WillOnce(testing::Return());
+    EXPECT_CALL(*sink, GetExitCode).WillOnce(testing::Return(EXIT_SUCCESS));
+  }
+
+  filter->Connect(std::move(sink));
+  src.Connect(std::move(filter));
+  EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
+
+  EXPECT_THAT(ServiceFilterTestAccessor::ContentFilter(*filter_ptr),
+      testing::UnorderedElementsAre(0x0102, 0x0103));
 }
 
 TEST(ServiceFilterTest, NoPacket) {


### PR DESCRIPTION
`MIRAKC_ARIB_ASSERT(pid != ts::PID_NULL);`

異常なTSが入力された場合に上記のassertionでクラッシュする問題を修正するPRです。
実際に私の環境でクラッシュが起きたため、修正を行いました。

私の環境で、mirakc-aribのコードのどの部分でおかしな値(NULL PID)がフィルターに混入したのかまでは分かってないですが、
入りうる箇所全てにガードを追加し、対応する部分のテストを追加してます。

NULL PIDだけでなく、明らかにフィルターに入れたらダメなPID（`psi_filter_`に常に固定でinsertしてるPID群）も
insertされるのを防いでます。