### PR TITLE
fix(record-service)!: always call `SendEventUpdateMessage()` in `OnEndOfChunk()`

### DIFF
--- a/src/service_recorder.hh
+++ b/src/service_recorder.hh
@@ -130,12 +130,16 @@ class ServiceRecorder final : public PacketSink,
     if (pos == sink_->ring_size()) {
       pos = 0;
     }
-    // The `event-update` message must be sent before the `chunk` message.
-    // The application may purge expired programs in the message handler for
-    // the `chunk` message.  So, the program data must be updated before that.
-    if (event_started_) {
-      SendEventUpdateMessage(eit_, now, pos);
-    }
+    // An `event-update` message MUST be sent before a `chunk` message.
+    //
+    // The application may purge expired TV programs in the message handler for
+    // the `chunk` message.  So, the TV program data must be updated before the
+    // purge occurs.
+    //
+    // The `event-update` message is ALWAYS sent to maintain the application's
+    // internal consistency even if no TV program starts.  In this case, the end
+    // time of the record for the last TV program (held by `eit_`) is extended.
+    SendEventUpdateMessage(eit_, now, pos);
     SendChunkMessage(now, pos);
   }
 

--- a/test/service_recorder_test.cc
+++ b/test/service_recorder_test.cc
@@ -826,3 +826,168 @@ TEST(ServiceRecorderTest, UnspecifiedEventEnd) {
   EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
   EXPECT_TRUE(src.IsEmpty());
 }
+
+TEST(ServiceRecorderTest, EndOfChunkBeforeNextEvent) {
+  ServiceRecorderOption option = kOption;
+
+  TableSource src;
+  auto ring_sink = std::make_unique<MockRingSink>(option.chunk_size, option.num_chunks);
+  auto json_sink = std::make_unique<MockJsonlSink>();
+
+  // <generic_short_table> elements are used for emulating PES and PCR packets.
+  src.LoadXml(R"(
+    <?xml version="1.0" encoding="utf-8"?>
+    <tsduck>
+      <PAT version="1" current="true" transport_stream_id="0x0002"
+           test-pid="0x0000">
+        <service service_id="0x0003" program_map_PID="0x0101" />
+      </PAT>
+      <PMT version="1" current="true" service_id="0x0003" PCR_PID="0x901"
+           test-pid="0x0101">
+        <component elementary_PID="0x0301" stream_type="0x02" />
+      </PMT>
+      <TOT UTC_time="2021-01-01 00:00:00" test-pid="0x0014" />
+      <generic_short_table table_id="0xFF" test-pid="0x0901" test-pcr="0" />
+      <EIT type="pf" version="1" current="true" actual="true"
+           service_id="0x0003" transport_stream_id="0x0002"
+           original_network_id="0x0001" last_table_id="0x4E"
+           test-pid="0x0012">
+        <event event_id="4" start_time="2021-01-01 00:00:00"
+               duration="00:00:01" running_status="undefined" CA_mode="true" />
+        <event event_id="5" start_time="2021-01-01 00:00:01"
+               duration="00:00:01" running_status="undefined" CA_mode="true" />
+      </EIT>
+      <generic_short_table table_id="0xFF" test-pid="0x0901" test-pcr="1" />
+      <generic_short_table table_id="0xFF" test-pid="0x0301" />
+      <generic_short_table table_id="0xFF" test-pid="0x0901" test-pcr="27000000" />
+      <generic_short_table table_id="0xFF" test-pid="0x0FFE" />
+      <EIT type="pf" version="2" current="true" actual="true"
+           service_id="0x0003" transport_stream_id="0x0002"
+           original_network_id="0x0001" last_table_id="0x4E"
+           test-pid="0x0012" test-cc="1">
+        <event event_id="5" start_time="2021-01-01 00:00:01"
+               duration="00:00:01" running_status="undefined" CA_mode="true" />
+        <event event_id="6" start_time="2021-01-01 00:00:02"
+               duration="00:00:01" running_status="undefined" CA_mode="true" />
+      </EIT>
+    </tsduck>
+  )");
+
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*ring_sink, Start).WillOnce(testing::Return(true));
+    EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+      EXPECT_EQ(R"({"type":"start"})", MockJsonlSink::Stringify(doc));
+      return true;
+    });
+    EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+      EXPECT_EQ(R"({"type":"chunk","data":{"chunk":{)"
+                R"("timestamp":1609426800000,"pos":0)"
+                R"(}}})",
+          MockJsonlSink::Stringify(doc));
+      return true;
+    });
+    EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+      EXPECT_EQ(R"({"type":"event-start","data":{)"
+                R"("originalNetworkId":1,)"
+                R"("transportStreamId":2,)"
+                R"("serviceId":3,)"
+                R"("event":{)"
+                R"("eventId":4,)"
+                R"("startTime":1609426800000,)"
+                R"("duration":1000,)"
+                R"("scrambled":true,)"
+                R"("descriptors":[])"
+                R"(},)"
+                R"("record":{)"
+                R"("timestamp":1609426800000,)"
+                R"("pos":0)"
+                R"(})"
+                R"(}})",
+          MockJsonlSink::Stringify(doc));
+      return true;
+    });
+    EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+      EXPECT_EQ(R"({"type":"event-end","data":{)"
+                R"("originalNetworkId":1,)"
+                R"("transportStreamId":2,)"
+                R"("serviceId":3,)"
+                R"("event":{)"
+                R"("eventId":4,)"
+                R"("startTime":1609426800000,)"
+                R"("duration":1000,)"
+                R"("scrambled":true,)"
+                R"("descriptors":[])"
+                R"(},)"
+                R"("record":{)"
+                R"("timestamp":1609426801000,)"
+                R"("pos":376)"
+                R"(})"
+                R"(}})",
+          MockJsonlSink::Stringify(doc));
+      return true;
+    });
+    // "event-update" and "chunk" messages will always sent ServiceRecorder::OnEndOfChunk()
+    // even if the next TV program does not start.
+    EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+      EXPECT_EQ(R"({"type":"event-update","data":{)"
+                R"("originalNetworkId":1,)"
+                R"("transportStreamId":2,)"
+                R"("serviceId":3,)"
+                R"("event":{)"
+                R"("eventId":4,)"
+                R"("startTime":1609426800000,)"
+                R"("duration":1000,)"
+                R"("scrambled":true,)"
+                R"("descriptors":[])"
+                R"(},)"
+                R"("record":{)"
+                R"("timestamp":1609426801000,)"
+                R"("pos":16384)"
+                R"(})"
+                R"(}})",
+          MockJsonlSink::Stringify(doc));
+      return true;
+    });
+    EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+      EXPECT_EQ(R"({"type":"chunk","data":{"chunk":{)"
+                R"("timestamp":1609426801000,"pos":16384)"
+                R"(}}})",
+          MockJsonlSink::Stringify(doc));
+      return true;
+    });
+    // The next TV program always starts at the end of the previous TV program.
+    EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+      EXPECT_EQ(R"({"type":"event-start","data":{)"
+                R"("originalNetworkId":1,)"
+                R"("transportStreamId":2,)"
+                R"("serviceId":3,)"
+                R"("event":{)"
+                R"("eventId":5,)"
+                R"("startTime":1609426801000,)"
+                R"("duration":1000,)"
+                R"("scrambled":true,)"
+                R"("descriptors":[])"
+                R"(},)"
+                R"("record":{)"
+                R"("timestamp":1609426801000,)"
+                R"("pos":376)"
+                R"(})"
+                R"(}})",
+          MockJsonlSink::Stringify(doc));
+      return true;
+    });
+    EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+      EXPECT_EQ(R"({"type":"stop","data":{"reset":false}})", MockJsonlSink::Stringify(doc));
+      return true;
+    });
+    EXPECT_CALL(*ring_sink, End).WillOnce(testing::Return());
+  }
+
+  auto recorder = std::make_unique<ServiceRecorder>(kOption);
+  recorder->ServiceRecorder::Connect(std::move(ring_sink));
+  recorder->JsonlSource::Connect(std::move(json_sink));
+  src.Connect(std::move(recorder));
+  EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
+  EXPECT_TRUE(src.IsEmpty());
+}

--- a/test/service_recorder_test.cc
+++ b/test/service_recorder_test.cc
@@ -27,10 +27,8 @@
 #include "test_helper.hh"
 
 namespace {
-constexpr size_t kNumBuffers = 2;
+constexpr size_t kChunkSize = 4096 * 4;  // 16KB
 constexpr size_t kNumChunks = 2;
-constexpr size_t kChunkSize = RingFileSink::kBufferSize * kNumBuffers;
-constexpr uint64_t kRingSize = kChunkSize * kNumChunks;
 const ServiceRecorderOption kOption{"/dev/null", 3, kChunkSize, kNumChunks};
 
 class ServiceRecorderTestAccessor final {
@@ -49,11 +47,12 @@ TEST(ServiceRecorderTest, NoPacket) {
   ServiceRecorderOption option = kOption;
 
   MockSource src;
-  auto file = std::make_unique<MockFile>();
+  auto ring_sink = std::make_unique<MockRingSink>(option.chunk_size, option.num_chunks);
   auto json_sink = std::make_unique<MockJsonlSink>();
 
   {
     testing::InSequence seq;
+    EXPECT_CALL(*ring_sink, Start).WillOnce(testing::Return(true));
     EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
       EXPECT_EQ(R"({"type":"start"})", MockJsonlSink::Stringify(doc));
       return true;
@@ -62,14 +61,13 @@ TEST(ServiceRecorderTest, NoPacket) {
       EXPECT_EQ(R"({"type":"stop","data":{"reset":false}})", MockJsonlSink::Stringify(doc));
       return true;
     });
+    EXPECT_CALL(*ring_sink, End).WillOnce(testing::Return());
   }
 
   EXPECT_CALL(src, GetNextPacket).WillOnce(testing::Return(false));  // EOF
 
-  auto ring =
-      std::make_unique<RingFileSink>(std::move(file), option.chunk_size, option.num_chunks);
   auto recorder = std::make_unique<ServiceRecorder>(kOption);
-  recorder->ServiceRecorder::Connect(std::move(ring));
+  recorder->ServiceRecorder::Connect(std::move(ring_sink));
   recorder->JsonlSource::Connect(std::move(json_sink));
   src.Connect(std::move(recorder));
   EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
@@ -113,7 +111,7 @@ TEST(ServiceRecorderTest, EventStart) {
   ServiceRecorderOption option = kOption;
 
   TableSource src;
-  auto file = std::make_unique<MockFile>();
+  auto ring_sink = std::make_unique<MockRingSink>(option.chunk_size, option.num_chunks);
   auto json_sink = std::make_unique<MockJsonlSink>();
 
   // <generic_short_table> elements are used for emulating PES and PCR packets.
@@ -146,6 +144,7 @@ TEST(ServiceRecorderTest, EventStart) {
 
   {
     testing::InSequence seq;
+    EXPECT_CALL(*ring_sink, Start).WillOnce(testing::Return(true));
     EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
       EXPECT_EQ(R"({"type":"start"})", MockJsonlSink::Stringify(doc));
       return true;
@@ -181,17 +180,11 @@ TEST(ServiceRecorderTest, EventStart) {
       EXPECT_EQ(R"({"type":"stop","data":{"reset":false}})", MockJsonlSink::Stringify(doc));
       return true;
     });
+    EXPECT_CALL(*ring_sink, End).WillOnce(testing::Return());
   }
 
-  EXPECT_CALL(*file, Write).WillRepeatedly(testing::Return(RingFileSink::kBufferSize));
-  EXPECT_CALL(*file, Sync).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(*file, Trunc).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(*file, Seek).WillRepeatedly(testing::Return(0));
-
-  auto ring =
-      std::make_unique<RingFileSink>(std::move(file), option.chunk_size, option.num_chunks);
   auto recorder = std::make_unique<ServiceRecorder>(kOption);
-  recorder->ServiceRecorder::Connect(std::move(ring));
+  recorder->ServiceRecorder::Connect(std::move(ring_sink));
   recorder->JsonlSource::Connect(std::move(json_sink));
   src.Connect(std::move(recorder));
   EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
@@ -341,7 +334,7 @@ TEST(ServiceRecorderTest, EventEnd) {
   ServiceRecorderOption option = kOption;
 
   TableSource src;
-  auto file = std::make_unique<MockFile>();
+  auto ring_sink = std::make_unique<MockRingSink>(option.chunk_size, option.num_chunks);
   auto json_sink = std::make_unique<MockJsonlSink>();
 
   // <generic_short_table> elements are used for emulating PES and PCR packets.
@@ -384,6 +377,7 @@ TEST(ServiceRecorderTest, EventEnd) {
 
   {
     testing::InSequence seq;
+    EXPECT_CALL(*ring_sink, Start).WillOnce(testing::Return(true));
     EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
       EXPECT_EQ(R"({"type":"start"})", MockJsonlSink::Stringify(doc));
       return true;
@@ -459,17 +453,11 @@ TEST(ServiceRecorderTest, EventEnd) {
       EXPECT_EQ(R"({"type":"stop","data":{"reset":false}})", MockJsonlSink::Stringify(doc));
       return true;
     });
+    EXPECT_CALL(*ring_sink, End).WillOnce(testing::Return());
   }
 
-  EXPECT_CALL(*file, Write).WillRepeatedly(testing::Return(RingFileSink::kBufferSize));
-  EXPECT_CALL(*file, Sync).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(*file, Trunc).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(*file, Seek).WillRepeatedly(testing::Return(0));
-
-  auto ring =
-      std::make_unique<RingFileSink>(std::move(file), option.chunk_size, option.num_chunks);
   auto recorder = std::make_unique<ServiceRecorder>(kOption);
-  recorder->ServiceRecorder::Connect(std::move(ring));
+  recorder->ServiceRecorder::Connect(std::move(ring_sink));
   recorder->JsonlSource::Connect(std::move(json_sink));
   src.Connect(std::move(recorder));
   EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
@@ -480,7 +468,7 @@ TEST(ServiceRecorderTest, EventStartBeforeEventEnd) {
   ServiceRecorderOption option = kOption;
 
   TableSource src;
-  auto file = std::make_unique<MockFile>();
+  auto ring_sink = std::make_unique<MockRingSink>(option.chunk_size, option.num_chunks);
   auto json_sink = std::make_unique<MockJsonlSink>();
 
   // <generic_short_table> elements are used for emulating PES and PCR packets.
@@ -522,6 +510,7 @@ TEST(ServiceRecorderTest, EventStartBeforeEventEnd) {
 
   {
     testing::InSequence seq;
+    EXPECT_CALL(*ring_sink, Start).WillOnce(testing::Return(true));
     EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
       EXPECT_EQ(R"({"type":"start"})", MockJsonlSink::Stringify(doc));
       return true;
@@ -597,17 +586,11 @@ TEST(ServiceRecorderTest, EventStartBeforeEventEnd) {
       EXPECT_EQ(R"({"type":"stop","data":{"reset":false}})", MockJsonlSink::Stringify(doc));
       return true;
     });
+    EXPECT_CALL(*ring_sink, End).WillOnce(testing::Return());
   }
 
-  EXPECT_CALL(*file, Write).WillRepeatedly(testing::Return(RingFileSink::kBufferSize));
-  EXPECT_CALL(*file, Sync).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(*file, Trunc).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(*file, Seek).WillRepeatedly(testing::Return(0));
-
-  auto ring =
-      std::make_unique<RingFileSink>(std::move(file), option.chunk_size, option.num_chunks);
   auto recorder = std::make_unique<ServiceRecorder>(kOption);
-  recorder->ServiceRecorder::Connect(std::move(ring));
+  recorder->ServiceRecorder::Connect(std::move(ring_sink));
   recorder->JsonlSource::Connect(std::move(json_sink));
   src.Connect(std::move(recorder));
   EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
@@ -618,7 +601,7 @@ TEST(ServiceRecorderTest, FirstEventAlreadyEnded) {
   ServiceRecorderOption option = kOption;
 
   TableSource src;
-  auto file = std::make_unique<MockFile>();
+  auto ring_sink = std::make_unique<MockRingSink>(option.chunk_size, option.num_chunks);
   auto json_sink = std::make_unique<MockJsonlSink>();
 
   // <generic_short_table> elements are used for emulating PES and PCR packets.
@@ -660,6 +643,7 @@ TEST(ServiceRecorderTest, FirstEventAlreadyEnded) {
 
   {
     testing::InSequence seq;
+    EXPECT_CALL(*ring_sink, Start).WillOnce(testing::Return(true));
     EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
       EXPECT_EQ(R"({"type":"start"})", MockJsonlSink::Stringify(doc));
       return true;
@@ -695,17 +679,11 @@ TEST(ServiceRecorderTest, FirstEventAlreadyEnded) {
       EXPECT_EQ(R"({"type":"stop","data":{"reset":false}})", MockJsonlSink::Stringify(doc));
       return true;
     });
+    EXPECT_CALL(*ring_sink, End).WillOnce(testing::Return());
   }
 
-  EXPECT_CALL(*file, Write).WillRepeatedly(testing::Return(RingFileSink::kBufferSize));
-  EXPECT_CALL(*file, Sync).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(*file, Trunc).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(*file, Seek).WillRepeatedly(testing::Return(0));
-
-  auto ring =
-      std::make_unique<RingFileSink>(std::move(file), option.chunk_size, option.num_chunks);
   auto recorder = std::make_unique<ServiceRecorder>(kOption);
-  recorder->ServiceRecorder::Connect(std::move(ring));
+  recorder->ServiceRecorder::Connect(std::move(ring_sink));
   recorder->JsonlSource::Connect(std::move(json_sink));
   src.Connect(std::move(recorder));
   EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
@@ -716,7 +694,7 @@ TEST(ServiceRecorderTest, UnspecifiedEventEnd) {
   ServiceRecorderOption option = kOption;
 
   TableSource src;
-  auto file = std::make_unique<MockFile>();
+  auto ring_sink = std::make_unique<MockRingSink>(option.chunk_size, option.num_chunks);
   auto json_sink = std::make_unique<MockJsonlSink>();
 
   // <generic_short_table> elements are used for emulating PES and PCR packets.
@@ -762,6 +740,7 @@ TEST(ServiceRecorderTest, UnspecifiedEventEnd) {
 
   {
     testing::InSequence seq;
+    EXPECT_CALL(*ring_sink, Start).WillOnce(testing::Return(true));
     EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
       EXPECT_EQ(R"({"type":"start"})", MockJsonlSink::Stringify(doc));
       return true;
@@ -837,17 +816,11 @@ TEST(ServiceRecorderTest, UnspecifiedEventEnd) {
       EXPECT_EQ(R"({"type":"stop","data":{"reset":false}})", MockJsonlSink::Stringify(doc));
       return true;
     });
+    EXPECT_CALL(*ring_sink, End).WillOnce(testing::Return());
   }
 
-  EXPECT_CALL(*file, Write).WillRepeatedly(testing::Return(RingFileSink::kBufferSize));
-  EXPECT_CALL(*file, Sync).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(*file, Trunc).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(*file, Seek).WillRepeatedly(testing::Return(0));
-
-  auto ring =
-      std::make_unique<RingFileSink>(std::move(file), option.chunk_size, option.num_chunks);
   auto recorder = std::make_unique<ServiceRecorder>(kOption);
-  recorder->ServiceRecorder::Connect(std::move(ring));
+  recorder->ServiceRecorder::Connect(std::move(ring_sink));
   recorder->JsonlSource::Connect(std::move(json_sink));
   src.Connect(std::move(recorder));
   EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());


### PR DESCRIPTION
BREAKING CHANGE: An `event-update` message will be always sent event if no TV program starts.

As described in the comment in the source file, in this case, the end time of the record for the last TV program (held by `eit_`) is extended.

Fixes: #165