### PR TITLE
prevent abort on malformed TOT/PCR

### DIFF
--- a/src/service_filter.hh
+++ b/src/service_filter.hh
@@ -353,6 +353,10 @@ class ServiceFilter final : public PacketSink, public ts::TableHandlerInterface 
   }
 
   void HandleTot(const ts::BinaryTable& table) {
+    if (!option_.time_limit.has_value()) {
+      return;
+    }
+
     ts::TOT tot(context_, table);
 
     if (!tot.isValid()) {

--- a/src/service_filter.hh
+++ b/src/service_filter.hh
@@ -135,7 +135,7 @@ class ServiceFilter final : public PacketSink, public ts::TableHandlerInterface 
     return true;
   }
 
-  static constexpr std::array<ts::PID, 9> kReservedPsiPids = {
+  static constexpr std::array<ts::PID, 9> kPsiFilterPids = {
       ts::PID_PAT,
       ts::PID_CAT,
       ts::PID_NIT,
@@ -154,11 +154,14 @@ class ServiceFilter final : public PacketSink, public ts::TableHandlerInterface 
       return false;
     }
 
-    // Reserved PSI/SI PIDs are already registered in psi_filter_, so re-adding them to a
-    // dynamic filter set is redundant.  (Rejecting them here also keeps a reserved PID from
-    // ever becoming pmt_pid_, which would corrupt demux_ on the next removePID.)
-    for (auto reserved_pid : kReservedPsiPids) {
-      if (pid == reserved_pid) {
+    // After a valid PAT is accepted, PSI/SI PIDs in kPsiFilterPids are already registered in
+    // psi_filter_.  Adding these PIDs to another filter set would serve no purpose.
+    //
+    // Rejecting them here also keeps a PID already registered in demux_ (PAT, CAT, or TOT if
+    // time_limit is set) from becoming pmt_pid_; otherwise, a later PMT PID change would then
+    // remove that PID from demux_ via `removePID()`.
+    for (auto psi_pid : kPsiFilterPids) {
+      if (pid == psi_pid) {
         return false;
       }
     }
@@ -252,7 +255,7 @@ class ServiceFilter final : public PacketSink, public ts::TableHandlerInterface 
     pat_packetizer_.removeAll();
     pat_packetizer_.addTable(context_, pat);
 
-    for (auto pid : kReservedPsiPids) {
+    for (auto pid : kPsiFilterPids) {
       psi_filter_.insert(pid);
     }
 

--- a/src/service_filter.hh
+++ b/src/service_filter.hh
@@ -356,10 +356,6 @@ class ServiceFilter final : public PacketSink, public ts::TableHandlerInterface 
   }
 
   void HandleTot(const ts::BinaryTable& table) {
-    if (!option_.time_limit.has_value()) {
-      return;
-    }
-
     ts::TOT tot(context_, table);
 
     if (!tot.isValid()) {
@@ -371,6 +367,10 @@ class ServiceFilter final : public PacketSink, public ts::TableHandlerInterface 
   }
 
   void CheckTimeLimit(const ts::Time& jst_time) {
+    if (!option_.time_limit.has_value()) {
+      return;
+    }
+
     if (jst_time < option_.time_limit.value()) {
       return;
     }

--- a/src/service_recorder.hh
+++ b/src/service_recorder.hh
@@ -47,6 +47,8 @@ struct ServiceRecorderOption final {
   uint64_t start_pos = 0;
 };
 
+class ServiceRecorderTestAccessor;
+
 class ServiceRecorder final : public PacketSink,
                               public JsonlSource,
                               public PacketRingObserver,
@@ -101,8 +103,10 @@ class ServiceRecorder final : public PacketSink,
     auto pid = packet.getPID();
     if (clock_.HasPid() && clock_.pid() == pid && packet.hasPCR()) {
       auto pcr = packet.getPCR();
-      if (pcr != ts::INVALID_PCR) {
+      if (IsValidPcr(pcr)) {
         clock_.UpdatePcr(pcr);
+      } else {
+        MIRAKC_ARIB_SERVICE_RECORDER_WARN("Ignore invalid PCR: {:011X}", pcr);
       }
     }
 
@@ -472,6 +476,8 @@ class ServiceRecorder final : public PacketSink,
   ts::PID pmt_pid_ = ts::PID_NULL;
   State state_ = State::kPreparing;
   bool event_started_ = false;
+
+  friend class ServiceRecorderTestAccessor;
 
   MIRAKC_ARIB_NON_COPYABLE(ServiceRecorder);
 };

--- a/test/service_filter_test.cc
+++ b/test/service_filter_test.cc
@@ -52,6 +52,10 @@ class ServiceFilterTestAccessor final {
   static const ts::SectionDemux& Demux(const ServiceFilter& filter) {
     return filter.demux_;
   }
+
+  static bool Done(const ServiceFilter& filter) {
+    return filter.done_;
+  }
 };
 
 }  // namespace
@@ -701,6 +705,42 @@ TEST(ServiceFilterTest, TimeLimitTot) {
   src.Connect(std::move(filter));
   EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
   EXPECT_EQ(1, src.GetNumberOfRemainingPackets());
+}
+
+TEST(ServiceFilterTest, IgnoreTotWhenTimeLimitIsUnset) {
+  TableSource src;
+  auto filter = std::make_unique<ServiceFilter>(kOption);
+  auto* filter_ptr = filter.get();
+  auto sink = std::make_unique<MockSink>();
+
+  // When `option_.time_limit` is unset, HandleTot must ignore the TOT; done_ must
+  // remain false so that streaming continues.
+  src.LoadXml(R"(
+    <?xml version="1.0" encoding="utf-8"?>
+    <tsduck>
+      <!-- PID_TOT is demuxed only when a time limit is set, but a malformed TS can
+           still carry a TOT on another demuxed PID. 0x0001 is PID_CAT, which is
+           always demuxed, so this TOT reaches HandleTot. -->
+      <TOT UTC_time="2019-01-02 03:04:05" test-pid="0x0001" />
+    </tsduck>
+  )");
+
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*sink, Start).WillOnce(testing::Return(true));
+    EXPECT_CALL(*sink, End).WillOnce(testing::Return());
+    EXPECT_CALL(*sink, GetExitCode).WillOnce(testing::Return(EXIT_SUCCESS));
+  }
+
+  // No PAT is fed, so psi_filter_ remains empty and CheckFilterForDrop drops
+  // every packet, including PID_CAT (0x0001). Therefore, no packets reach the sink.
+  EXPECT_CALL(*sink, HandlePacket).Times(0);
+
+  filter->Connect(std::move(sink));
+  src.Connect(std::move(filter));
+  EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
+
+  EXPECT_FALSE(ServiceFilterTestAccessor::Done(*filter_ptr));
 }
 
 TEST(ServiceFilterTest, Subtitle) {

--- a/test/service_filter_test.cc
+++ b/test/service_filter_test.cc
@@ -713,8 +713,8 @@ TEST(ServiceFilterTest, IgnoreTotWhenTimeLimitIsUnset) {
   auto* filter_ptr = filter.get();
   auto sink = std::make_unique<MockSink>();
 
-  // When `option_.time_limit` is unset, HandleTot must ignore the TOT; done_ must
-  // remain false so that streaming continues.
+  // When `option_.time_limit` is unset, CheckTimeLimit must ignore the TOT time;
+  // done_ must remain false so that streaming continues.
   src.LoadXml(R"(
     <?xml version="1.0" encoding="utf-8"?>
     <tsduck>

--- a/test/service_filter_test.cc
+++ b/test/service_filter_test.cc
@@ -76,7 +76,7 @@ TEST(ServiceFilterTest, IsSafeDynamicPid) {
   EXPECT_TRUE(ServiceFilterTestAccessor::IsSafeDynamicPid(0x1FFE));
 }
 
-TEST(ServiceFilterTest, RejectUnsafePmtPidFromPat) {
+TEST(ServiceFilterTest, IgnoreUnsafePmtPidFromPat) {
   TableSource src;
   auto filter = std::make_unique<ServiceFilter>(kOption);
   auto* filter_ptr = filter.get();
@@ -84,7 +84,7 @@ TEST(ServiceFilterTest, RejectUnsafePmtPidFromPat) {
 
   // The 1st PAT advertises ts::PID_NULL (0x1FFF) as a PMT PID.
   // The 2nd PAT advertises 0x0101 as a PMT PID.
-  // Only 0x0101 must be added to psi_filter_ and demux_.
+  // Of the two advertised PMT PIDs, only 0x0101 must be added to psi_filter_ and demux_.
   // ts::PID_NULL must never be added to psi_filter_ or demux_.
   src.LoadXml(R"(
     <?xml version="1.0" encoding="utf-8"?>
@@ -119,7 +119,8 @@ TEST(ServiceFilterTest, RejectUnsafePmtPidFromPat) {
       testing::UnorderedElementsAre(ts::PID_PAT, ts::PID_CAT, ts::PID_NIT, ts::PID_SDT,
           ts::PID_EIT, ts::PID_RST, ts::PID_TOT, ts::PID_BIT, ts::PID_CDT, 0x0101));
 
-  // demux_ must retain PIDs added in the constructor and now include the safe PMT PID.
+  // demux_ must still contain the PIDs added in the constructor, in addition to the safe PMT PID
+  // (0x0101).
   EXPECT_TRUE(ServiceFilterTestAccessor::Demux(*filter_ptr).hasPID(ts::PID_PAT));
   EXPECT_TRUE(ServiceFilterTestAccessor::Demux(*filter_ptr).hasPID(ts::PID_CAT));
   EXPECT_TRUE(ServiceFilterTestAccessor::Demux(*filter_ptr).hasPID(0x0101));
@@ -127,13 +128,13 @@ TEST(ServiceFilterTest, RejectUnsafePmtPidFromPat) {
   EXPECT_FALSE(ServiceFilterTestAccessor::Demux(*filter_ptr).hasPID(ts::PID_NULL));
 }
 
-TEST(ServiceFilterTest, RejectUnsafeEmmPidsFromCatDescriptors) {
+TEST(ServiceFilterTest, IgnoreUnsafeEmmPidsFromCatDescriptors) {
   TableSource src;
   auto filter = std::make_unique<ServiceFilter>(kOption);
   auto* filter_ptr = filter.get();
   auto sink = std::make_unique<MockSink>();
 
-  // This CAT advertises 0x0101 and ts::PID_EIT (0x0012) as CA PIDs.
+  // This CAT advertises 0x0101 and ts::PID_EIT (0x0012) as EMM PIDs in CA descriptors.
   // Only 0x0101 must be added to emm_filter_.
   // ts::PID_EIT must never be added to emm_filter_.
   src.LoadXml(R"(
@@ -153,8 +154,7 @@ TEST(ServiceFilterTest, RejectUnsafeEmmPidsFromCatDescriptors) {
     EXPECT_CALL(*sink, GetExitCode).WillOnce(testing::Return(EXIT_SUCCESS));
   }
 
-  // Only a CAT is fed, and ServiceFilter consumes it without forwarding,
-  // so no packets reach the sink.
+  // Since no PAT is fed, psi_filter_ remains empty, so the CAT packet does not reach the sink.
   EXPECT_CALL(*sink, HandlePacket).Times(0);
 
   filter->Connect(std::move(sink));
@@ -165,7 +165,7 @@ TEST(ServiceFilterTest, RejectUnsafeEmmPidsFromCatDescriptors) {
       ServiceFilterTestAccessor::EmmFilter(*filter_ptr), testing::UnorderedElementsAre(0x0101));
 }
 
-TEST(ServiceFilterTest, RejectUnsafePcrPidFromPmt) {
+TEST(ServiceFilterTest, IgnoreUnsafePcrPidFromPmt) {
   TableSource src;
   auto filter = std::make_unique<ServiceFilter>(kOption);
   auto* filter_ptr = filter.get();
@@ -211,14 +211,14 @@ TEST(ServiceFilterTest, RejectUnsafePcrPidFromPmt) {
       testing::UnorderedElementsAre(0x0103));
 }
 
-TEST(ServiceFilterTest, RejectUnsafeEcmPidsFromPmtDescriptors) {
+TEST(ServiceFilterTest, IgnoreUnsafeEcmPidsFromPmtDescriptors) {
   TableSource src;
   auto filter = std::make_unique<ServiceFilter>(kOption);
   auto* filter_ptr = filter.get();
   auto sink = std::make_unique<MockSink>();
 
   // This PMT advertises 0x0103 and ts::PID_NIT (0x0010) as ECM PIDs.
-  // Only 0x0103 must be added to content_filter_.
+  // Of the two advertised ECM PIDs, only 0x0103 must be added to content_filter_.
   // ts::PID_NIT must never be added to content_filter_.
   src.LoadXml(R"(
     <?xml version="1.0" encoding="utf-8"?>
@@ -258,14 +258,14 @@ TEST(ServiceFilterTest, RejectUnsafeEcmPidsFromPmtDescriptors) {
       testing::UnorderedElementsAre(0x0102, 0x0103));
 }
 
-TEST(ServiceFilterTest, RejectUnsafeStreamPidsFromPmtStreams) {
+TEST(ServiceFilterTest, IgnoreUnsafeStreamPidsFromPmtStreams) {
   TableSource src;
   auto filter = std::make_unique<ServiceFilter>(kOption);
   auto* filter_ptr = filter.get();
   auto sink = std::make_unique<MockSink>();
 
   // This PMT advertises 0x0103 and ts::PID_NULL (0x1FFF) as stream PIDs.
-  // Only 0x0103 must be added to content_filter_.
+  // Of the two advertised stream PIDs, only 0x0103 must be added to content_filter_.
   // ts::PID_NULL must never be added to content_filter_.
   src.LoadXml(R"(
     <?xml version="1.0" encoding="utf-8"?>

--- a/test/service_recorder_test.cc
+++ b/test/service_recorder_test.cc
@@ -32,6 +32,17 @@ constexpr size_t kNumChunks = 2;
 constexpr size_t kChunkSize = RingFileSink::kBufferSize * kNumBuffers;
 constexpr uint64_t kRingSize = kChunkSize * kNumChunks;
 const ServiceRecorderOption kOption{"/dev/null", 3, kChunkSize, kNumChunks};
+
+class ServiceRecorderTestAccessor final {
+ public:
+  static void SetClockPid(ServiceRecorder& recorder, ts::PID pid) {
+    recorder.clock_.SetPid(pid);
+  }
+
+  static bool ClockIsReady(const ServiceRecorder& recorder) {
+    return recorder.clock_.IsReady();
+  }
+};
 }  // namespace
 
 TEST(ServiceRecorderTest, NoPacket) {
@@ -62,6 +73,40 @@ TEST(ServiceRecorderTest, NoPacket) {
   recorder->JsonlSource::Connect(std::move(json_sink));
   src.Connect(std::move(recorder));
   EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
+}
+
+TEST(ServiceRecorderTest, IgnoreInvalidPcr) {
+  TableSource src;
+  auto ring_sink = std::make_unique<MockRingSink>(kOption.chunk_size, kOption.num_chunks);
+  auto json_sink = std::make_unique<MockJsonlSink>();
+  auto recorder = std::make_unique<ServiceRecorder>(kOption);
+  auto* recorder_ptr = recorder.get();
+
+  // An invalid PCR (PCR_ext > 299, possible only with invalid TS) must not
+  // abort the recorder.  The value must be ignored, leaving the clock unready.
+  ServiceRecorderTestAccessor::SetClockPid(*recorder_ptr, 0x0901);
+
+  src.LoadXml(R"(
+    <?xml version="1.0" encoding="utf-8"?>
+    <tsduck>
+      <generic_short_table table_id="0xFF" test-pid="0x0901"
+           test-pcr="2576980377600" />
+    </tsduck>
+  )");
+
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*ring_sink, Start).WillOnce(testing::Return(true));
+    EXPECT_CALL(*ring_sink, End).WillOnce(testing::Return());
+  }
+  EXPECT_CALL(*json_sink, HandleDocument).WillRepeatedly(testing::Return(true));
+
+  recorder->ServiceRecorder::Connect(std::move(ring_sink));
+  recorder->JsonlSource::Connect(std::move(json_sink));
+  src.Connect(std::move(recorder));
+  EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
+
+  EXPECT_FALSE(ServiceRecorderTestAccessor::ClockIsReady(*recorder_ptr));
 }
 
 TEST(ServiceRecorderTest, EventStart) {

--- a/test/test_helper.hh
+++ b/test/test_helper.hh
@@ -168,6 +168,24 @@ class TableSource final : public PacketSource {
           packet.b[5] |= 0x10;
           assert(packet.hasPCR());
           assert(packet.getPCR() == ts::INVALID_PCR);
+        } else if (pcr > ts::MAX_PCR) {
+          // Craft an out-of-range (invalid) PCR to test how the code under test handles
+          // invalid TS.  ts::TSPacket::setPCR() asserts that the
+          // value is valid, so we encode the PCR field directly into the packet
+          // bytes here.
+          //
+          // PCR_ext is encoded in 9 bits, so values up to 511 can be
+          // represented even though valid PCR_ext values are limited to 0..299.
+          // This extra range lets us encode a PCR slightly above ts::MAX_PCR.
+          assert(pcr <= ts::MAX_PCR + (0x1FF - (ts::SYSTEM_CLOCK_SUBFACTOR - 1)));
+          packet.setPayloadSize(0);
+          packet.setPCR(ts::MAX_PCR);
+          auto pcr_ext =
+              static_cast<uint16_t>((ts::SYSTEM_CLOCK_SUBFACTOR - 1) + (pcr - ts::MAX_PCR));
+          packet.b[10] = static_cast<uint8_t>((packet.b[10] & 0xFE) | ((pcr_ext >> 8) & 0x01));
+          packet.b[11] = static_cast<uint8_t>(pcr_ext & 0xFF);
+          assert(packet.hasPCR());
+          assert(packet.getPCR() == pcr);
         } else {
           packet.setPayloadSize(0);
           packet.setPCR(pcr);


### PR DESCRIPTION
## 概要

不正TS受信時にServiceFilter、ServiceRecorderをabortさせる可能性のある
2つの問題を修正します。

## 修正内容

- **ServiceFilter**: `time_limit`が未設定でも、不正TSではPID_TOT以外のPID経由でTOTテーブルが`HandleTot`に届き、abortする場合がある。
  - 未設定の`option_.time_limit`を参照してしまい、`bad optional access`で異常終了する問題を修正します。
- **ServiceRecorder**: PCR値が存在するが、不正な値の場合をチェックしていない。不正PCR値が渡されると、[Clock::UpdatePcr()](https://github.com/mirakc/mirakc-arib/blob/d966328abbaf9ca12dc18bca510514bc124c5044/src/base.hh#L215)が行うassertが原因でabortする。
  - `MIRAKC_ARIB_ASSERT(IsValidPcr(pcr))`でabortしないように、呼び出し側も`IsValidPcr`を使いチェックし、不正なPCR値の場合は警告メッセージをログに出力した上でPCR値を無視するよう修正します。

## このPRスコープ外の内容

TOT以外のPIDでTOTテーブルが来ても弾けるよう、
`sourcePID`が通常の物と異なるテーブルを弾くコードを追加する事も考えましたが、
`option_.time_limit`に値が入っているかさえチェックすればabortは防げるので、一旦このPRでは対象外としています。

## その他

- #161 で追加したコードの変数の命名、コメントのうち分かりにくいものや、実態にあっておらず誤っていた物を同時に修正しています。
- 未設定の`option_.time_limit`を参照してしまい、abortしうる経路は過去にはもう一つ有りましたが、既に修正済みです。
  - #161 の修正前のコードでは、`pmt_pid`がPID_TOTになっている不正TSが入力された場合、TOTが誤って[addPID()](https://github.com/mirakc/mirakc-arib/blob/df771ed56e8725830132a9626498f93623386965/src/service_filter.hh#L237)でdemux対象になり、同様にabortする可能性があったものの、修正後は不正TSでTOTが誤ってdemux対象になる事はなくなりました。