### PR TITLE
test: define MIRAKC_ARIB_ENABLE_TESTING in test builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -881,6 +881,11 @@ if(MIRAKC_ARIB_TEST)
     test/tsduck_helper_test.cc
   )
 
+  target_compile_definitions(mirakc-arib-test
+    PRIVATE
+      MIRAKC_ARIB_ENABLE_TESTING
+  )
+
   target_include_directories(mirakc-arib-test
     PRIVATE
       src

--- a/src/main.cc
+++ b/src/main.cc
@@ -15,6 +15,10 @@
 // not, write to the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston, MA
 // 02110-1301, USA.
 
+#ifdef MIRAKC_ARIB_ENABLE_TESTING
+#error "MIRAKC_ARIB_ENABLE_TESTING must not be defined"
+#endif
+
 #include <cerrno>
 #include <cstddef>
 #include <cstring>

--- a/test/test.cc
+++ b/test/test.cc
@@ -15,6 +15,10 @@
 // not, write to the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston, MA
 // 02110-1301, USA.
 
+#ifndef MIRAKC_ARIB_ENABLE_TESTING
+#error "MIRAKC_ARIB_ENABLE_TESTING must be defined"
+#endif
+
 #include <gmock/gmock.h>
 #include <tsduck/tsduck.h>
 #include <spdlog/cfg/env.h>


### PR DESCRIPTION
this symbol can be used to add test-specific methods or for other verification purposes.