### PR TITLE
feat: initial packet-stats implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -807,6 +807,7 @@ add_executable(mirakc-arib
   src/main.cc
   src/packet_sink.hh
   src/packet_source.hh
+  src/packet_stats_collector.hh
   src/pcr_synchronizer.hh
   src/pes_printer.hh
   src/program_filter.hh
@@ -880,6 +881,7 @@ if(MIRAKC_ARIB_TEST)
     test/eitpf_collector_test.cc
     test/logo_collector_test.cc
     test/packet_source_test.cc
+    test/packet_stats_collector_test.cc
     test/pcr_synchronizer_test.cc
     test/program_filter_test.cc
     test/ring_file_sink_test.cc

--- a/src/main.cc
+++ b/src/main.cc
@@ -94,7 +94,7 @@ Usage:
     [--pre-streaming] [<file>]
   mirakc-arib filter-program-metadata [--sid=<sid>] [<file>]
   mirakc-arib record-service --sid=<sid> --file=<file>
-    --chunk-size=<bytes> --num-chunks=<num> [--start-pos=<pos>] [<file>]
+    --chunk-size=<bytes> --num-chunks=<num> [--start-pos=<pos>] [--packet-stats] [<file>]
   mirakc-arib track-airtime --sid=<sid> --eid=<eid> [<file>]
   mirakc-arib seek-start --sid=<sid>
     [--max-duration=<ms>] [--max-packets=<num>] [<file>]
@@ -651,7 +651,7 @@ Record a service stream into a ring buffer file
 
 Usage:
   mirakc-arib record-service --sid=<sid> --file=<file>
-    --chunk-size=<bytes> --num-chunks=<num> [--start-pos=<pos>] [<file>]
+    --chunk-size=<bytes> --num-chunks=<num> [--start-pos=<pos>] [--packet-stats] [<file>]
 
 Options:
   -h --help
@@ -673,6 +673,9 @@ Options:
   --start-pos=<pos>  [default: 0]
     A file position to start recoring.
     The value must be a multiple of the chunk size.
+
+  --packet-stats
+    Collect statistics on TS packets and send `packet-stats` messages.
 
 Arguments:
   <file>
@@ -760,6 +763,51 @@ JSON Messages:
   event-end
     The `event-end` message is sent when ended recoring a program.  The message
     structure is the same as the `event-start` message.
+
+  packet-stats
+    The `packet-stats` message is sent when `--packet-stats` is specified.
+    The message is sent immediately before each `chunk`, `event-end`, and `stop`
+    message, except for the first `chunk` message which is sent when recording
+    starts.  Each message reports statistics for the packets recorded since the
+    previous `packet-stats` message, or since recording started in the case of
+    the first message.  The counters are reset each time the message is sent.
+    The message structure is like below:
+
+      {{
+        "type": "packet-stats",
+        "data": {{
+          "errorPackets": 0,
+          "scrambledPackets": 0,
+          "droppedPackets": {{
+            "video": 0,
+            "audio": 0,
+            "subtitle": 0,
+            "pmt": 0
+          }}
+        }}
+      }}
+
+    where:
+      errorPackets
+        The number of TS packets with TEI (transport_error_indicator) set to 1.
+        Only packets retained by service filtering are counted.
+
+      scrambledPackets
+        The number of TS packets with TSC (transport_scrambling_control) set to
+        a nonzero value.  Only packets retained by service filtering are
+        counted.  Null packets and packets with TEI set are excluded because
+        their TSC value is not meaningful.
+
+      droppedPackets
+        The estimated number of missing TS packets, calculated from continuity
+        counter discontinuities and broken down by category.  Only packets
+        belonging to the selected service are counted.
+
+          video    PES packets carrying video.
+          audio    PES packets carrying audio.
+          subtitle PES packets carrying subtitles, including ARIB subtitles and
+                   superimposed text.
+          pmt      Packets carrying the selected service's PMT.
 
 Environment Variables:
   MIRAKC_ARIB_KEEP_UNICODE_SYMBOLS
@@ -1243,6 +1291,7 @@ void LoadOption(const Args& args, ServiceRecorderOption* opt) {
   static const std::string kChunkSize = "--chunk-size";
   static const std::string kNumChunks = "--num-chunks";
   static const std::string kStartPos = "--start-pos";
+  static const std::string kPacketStats = "--packet-stats";
 
   opt->sid = static_cast<uint16_t>(args.at(kSid).asLong());
   opt->file = args.at(kFile).asString();
@@ -1280,9 +1329,11 @@ void LoadOption(const Args& args, ServiceRecorderOption* opt) {
       std::abort();
     }
   }
+  opt->packet_stats = args.at(kPacketStats).asBool();
   MIRAKC_ARIB_INFO(
-      "ServiceRecorderOptions: sid={:04X} file={} chunk-size={} num-chunks={} start-pos={}",
-      opt->sid, opt->file, opt->chunk_size, opt->num_chunks, opt->start_pos);
+      "ServiceRecorderOptions: sid={:04X} file={} chunk-size={} num-chunks={} start-pos={} "
+      "packet-stats={}",
+      opt->sid, opt->file, opt->chunk_size, opt->num_chunks, opt->start_pos, opt->packet_stats);
 }
 
 void LoadOption(const Args& args, AirtimeTrackerOption* opt) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -690,12 +690,12 @@ JSON Messages:
         "type": "start"
       }}
 
-  end
-    The `end` message is sent when `record-service` ends.  The message structure
-    is like below:
+  stop
+    The `stop` message is sent when `record-service` ends.  The message
+    structure is like below:
 
       {{
-        "type": "end",
+        "type": "stop",
         "data": {{
           "reset": false,
         }}

--- a/src/packet_stats_collector.hh
+++ b/src/packet_stats_collector.hh
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// mirakc-arib
+// Copyright (C) 2019 masnagam
+//
+// This program is free software; you can redistribute it and/or modify it under the terms of the
+// GNU General Public License as published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+// the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program; if
+// not, write to the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston, MA
+// 02110-1301, USA.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include <tsduck/tsduck.h>
+
+#include "base.hh"
+#include "tsduck_helper.hh"
+
+namespace {
+
+enum class PacketCategory : uint8_t {
+  kVideo,
+  kAudio,
+  kSubtitle,
+  kPmt,
+  kNumCategories,
+};
+
+constexpr size_t kNumPacketCategories = static_cast<size_t>(PacketCategory::kNumCategories);
+
+constexpr std::array<const char*, kNumPacketCategories> kPacketCategoryNames = {
+    "video",
+    "audio",
+    "subtitle",
+    "pmt",
+};
+
+class PacketStatsCollector final {
+ public:
+  PacketStatsCollector() = default;
+
+  // Changes the PMT PID tracked for packet statistics after a PAT update.
+  void SetPmtPid(ts::PID pid) {
+    if (pmt_pid_ == pid) {
+      return;
+    }
+
+    const auto old_pid = pmt_pid_;
+    pmt_pid_ = pid;
+
+    if (old_pid.has_value()) {
+      RemoveCategory(*old_pid);
+    }
+
+    SetCategory(pid, PacketCategory::kPmt);
+  }
+
+  // Classifies each PID carried by `pmt` into a PacketCategory.
+  void UpdatePidCategories(const ts::PMT& pmt) {
+    RebuildPidCategories(pmt);
+  }
+
+  void CollectPacketStats(const ts::TSPacket& packet) {
+    // Packets with TEI set may have invalid PID or CC values.
+    // Count them as errors and return early.
+    if (packet.getTEI()) {
+      ++error_packets_;
+      return;
+    }
+
+    auto pid = packet.getPID();
+    if (pid == ts::PID_NULL) {
+      return;
+    }
+
+    if (packet.getScrambling() != 0) {
+      ++scrambled_packets_;
+    }
+
+    auto& stat = stats_[pid];
+    if (!stat.category.has_value()) {
+      return;
+    }
+
+    auto cc = packet.getCC();
+
+    // Although MPEG-2 TS permits a packet to be transmitted twice, we intentionally do not retain
+    // the previous packet to detect duplicates.
+    //
+    // We are not aware of any reports of duplicate packets in Japanese digital broadcasts, and
+    // we see little value in handling them.  If a duplicate payload packet is ever transmitted,
+    // its repeated CC is counted as 15 dropped packets.
+    if (stat.last_cc != ts::INVALID_CC && !packet.getDiscontinuityIndicator()) {
+      // The continuity counter increments only when the packet has a payload.
+      // Keep the expected CC unchanged for packets without payload.
+      uint8_t expected_cc =
+          packet.hasPayload() ? ((stat.last_cc + 1) & ts::CC_MASK) : stat.last_cc;
+
+      uint8_t missed = (cc - expected_cc) & ts::CC_MASK;
+      if (missed != 0) {
+        dropped_packets_[static_cast<size_t>(*stat.category)] += missed;
+      }
+    }
+
+    stat.last_cc = cc;
+  }
+
+  void ResetPacketStats() {
+    error_packets_ = 0;
+    scrambled_packets_ = 0;
+    dropped_packets_.fill(0);
+  }
+
+  uint64_t GetErrorPackets() const {
+    return error_packets_;
+  }
+
+  uint64_t GetScrambledPackets() const {
+    return scrambled_packets_;
+  }
+
+  uint64_t GetDroppedPackets(PacketCategory category) const {
+    MIRAKC_ARIB_ASSERT(static_cast<size_t>(category) < kNumPacketCategories);
+    return dropped_packets_[static_cast<size_t>(category)];
+  }
+
+ private:
+  struct PacketStat {
+    uint8_t last_cc = ts::INVALID_CC;
+    std::optional<PacketCategory> category;
+  };
+
+  static void ClearCategory(PacketStat& stat) {
+    stat.category.reset();
+    stat.last_cc = ts::INVALID_CC;
+  }
+
+  void SetCategory(ts::PID pid, PacketCategory category) {
+    auto& stat = stats_[pid];
+    if (!stat.category.has_value()) {
+      categorized_pids_.push_back(pid);
+    }
+    stat.category = category;
+  }
+
+  void RemoveCategory(ts::PID pid) {
+    ClearCategory(stats_[pid]);
+    const auto it = std::find(categorized_pids_.begin(), categorized_pids_.end(), pid);
+    if (it != categorized_pids_.end()) {
+      categorized_pids_.erase(it);
+    }
+  }
+
+  // Rebuilds packet-statistics PID categories from the tracked PMT PID and PMT.
+  void RebuildPidCategories(const ts::PMT& pmt) {
+    std::vector<ts::PID> previous_pids;
+    previous_pids.swap(categorized_pids_);
+
+    // Clear the previous category assignments before rebuilding them from the current PMT.
+    // Do not clear the last_cc of existing stats here, as it may still be used by the current PMT.
+    for (auto pid : previous_pids) {
+      stats_[pid].category.reset();
+    }
+
+    if (pmt_pid_.has_value()) {
+      SetCategory(*pmt_pid_, PacketCategory::kPmt);
+    }
+
+    RebuildStreamPidCategories(pmt);
+
+    // Clear both the category and saved CC for PIDs that are no longer tracked.
+    for (auto pid : previous_pids) {
+      if (!stats_[pid].category.has_value()) {
+        ClearCategory(stats_[pid]);
+      }
+    }
+  }
+
+  // Assigns categories to the PIDs referenced by `pmt`.
+  void RebuildStreamPidCategories(const ts::PMT& pmt) {
+    for (const auto& [pid, stream] : pmt.streams) {
+      // Do not classify the PMT PID as other categories.
+      if (pmt_pid_.has_value() && pid == *pmt_pid_) {
+        continue;
+      }
+
+      if (stream.isVideo()) {
+        SetCategory(pid, PacketCategory::kVideo);
+      } else if (stream.isAudio()) {
+        SetCategory(pid, PacketCategory::kAudio);
+      } else if (stream.isSubtitles() || IsAribSubtitle(stream) ||
+          IsAribSuperimposedText(stream)) {
+        SetCategory(pid, PacketCategory::kSubtitle);
+      }
+    }
+  }
+
+  MIRAKC_ARIB_NON_COPYABLE(PacketStatsCollector);
+  std::array<PacketStat, ts::PID_MAX> stats_;
+  std::vector<ts::PID> categorized_pids_;
+  std::optional<ts::PID> pmt_pid_;
+  uint64_t error_packets_ = 0;
+  uint64_t scrambled_packets_ = 0;
+  std::array<uint64_t, kNumPacketCategories> dropped_packets_{};
+};
+
+}  // namespace

--- a/src/service_recorder.hh
+++ b/src/service_recorder.hh
@@ -29,6 +29,7 @@
 #include "jsonl_source.hh"
 #include "logging.hh"
 #include "packet_sink.hh"
+#include "packet_stats_collector.hh"
 #include "tsduck_helper.hh"
 
 #define MIRAKC_ARIB_SERVICE_RECORDER_TRACE(...) MIRAKC_ARIB_TRACE("service-recorder: " __VA_ARGS__)
@@ -45,6 +46,7 @@ struct ServiceRecorderOption final {
   size_t chunk_size = 0;
   size_t num_chunks = 0;
   uint64_t start_pos = 0;
+  bool packet_stats = false;
 };
 
 class ServiceRecorderTestAccessor;
@@ -56,6 +58,9 @@ class ServiceRecorder final : public PacketSink,
  public:
   explicit ServiceRecorder(const ServiceRecorderOption& option)
       : option_(option), demux_(context_) {
+    if (option_.packet_stats) {
+      packet_stats_collector_ = std::make_unique<PacketStatsCollector>();
+    }
     demux_.setTableHandler(this);
     demux_.addPID(ts::PID_PAT);
     MIRAKC_ARIB_SERVICE_RECORDER_DEBUG("Demux PAT");
@@ -88,6 +93,7 @@ class ServiceRecorder final : public PacketSink,
 
   void End() override {
     MIRAKC_ARIB_ASSERT(sink_ != nullptr);
+    SendPacketStatsMessage();
     SendStopMessage(sink_->IsBroken());
     sink_->End();
   }
@@ -140,6 +146,7 @@ class ServiceRecorder final : public PacketSink,
     // internal consistency even if no TV program starts.  In this case, the end
     // time of the record for the last TV program (held by `eit_`) is extended.
     SendEventUpdateMessage(eit_, now, pos);
+    SendPacketStatsMessage();
     SendChunkMessage(now, pos);
   }
 
@@ -202,6 +209,10 @@ class ServiceRecorder final : public PacketSink,
     pmt_pid_ = new_pmt_pid;
     demux_.addPID(pmt_pid_);
     MIRAKC_ARIB_SERVICE_RECORDER_DEBUG("PAT: Demux += PMT#{:04X}", pmt_pid_);
+
+    if (packet_stats_collector_) {
+      packet_stats_collector_->SetPmtPid(pmt_pid_);
+    }
   }
 
   void HandlePmt(const ts::BinaryTable& table) {
@@ -215,6 +226,10 @@ class ServiceRecorder final : public PacketSink,
     if (pmt.service_id != option_.sid) {
       MIRAKC_ARIB_SERVICE_RECORDER_WARN("PMT: SID#{} not matched, skip", pmt.service_id);
       return;
+    }
+
+    if (packet_stats_collector_) {
+      packet_stats_collector_->UpdatePidCategories(pmt);
     }
 
     auto pcr_pid = pmt.pcr_pid;
@@ -326,8 +341,7 @@ class ServiceRecorder final : public PacketSink,
       if (event_changed) {
         MIRAKC_ARIB_SERVICE_RECORDER_WARN("Event#{:04X} has started before Event#{:04X} ends",
             GetEvent(new_eit).event_id, GetEvent(eit).event_id);
-        UpdateEventBoundary(now, sink_->pos());
-        SendEventEndMessage(eit);
+        HandleEventEnd(now, eit);
         SendEventStartMessage(new_eit);
       } else {
         if (IsUnspecifiedEventEndTime(GetEvent(eit))) {
@@ -335,8 +349,7 @@ class ServiceRecorder final : public PacketSink,
         } else {
           auto end_time = GetEventEndTime(GetEvent(eit));
           if (now >= end_time) {
-            UpdateEventBoundary(end_time, sink_->pos());
-            SendEventEndMessage(eit);
+            HandleEventEnd(end_time, eit);
             event_started_ = false;  // wait for new event
           }
         }
@@ -347,6 +360,14 @@ class ServiceRecorder final : public PacketSink,
         event_started_ = true;
       }
     }
+
+    // When option_.packet_stats is true, HandleEventEnd() sends a `packet-stats` message before
+    // the `event-end` message.  Collect the current TS packet after HandleEventEnd() so that the
+    // `packet-stats` message sent by HandleEventEnd() excludes the TS packet not yet written to
+    // the ring buffer.
+    if (packet_stats_collector_) {
+      packet_stats_collector_->CollectPacketStats(packet);
+    }
     return sink_->HandlePacket(packet);
   }
 
@@ -354,6 +375,12 @@ class ServiceRecorder final : public PacketSink,
     MIRAKC_ARIB_SERVICE_RECORDER_DEBUG("Update event boundary with {}@{}", time, pos);
     event_boundary_time_ = time;
     event_boundary_pos_ = pos;
+  }
+
+  void HandleEventEnd(const ts::Time& end_time, const std::shared_ptr<ts::EIT>& eit) {
+    UpdateEventBoundary(end_time, sink_->pos());
+    SendPacketStatsMessage();
+    SendEventEndMessage(eit);
   }
 
   void SendStartMessage() {
@@ -426,6 +453,44 @@ class ServiceRecorder final : public PacketSink,
     SendEventMessage("event-end", eit, event_boundary_time_, event_boundary_pos_);
   }
 
+  void SendPacketStatsMessage() {
+    if (!packet_stats_collector_) {
+      return;
+    }
+
+    auto error_packets = packet_stats_collector_->GetErrorPackets();
+    auto scrambled_packets = packet_stats_collector_->GetScrambledPackets();
+
+    rapidjson::Document doc(rapidjson::kObjectType);
+    auto& allocator = doc.GetAllocator();
+
+    rapidjson::Value dropped_packets(rapidjson::kObjectType);
+    std::string dropped_packets_log;
+    for (size_t i = 0; i < kNumPacketCategories; ++i) {
+      auto category = static_cast<PacketCategory>(i);
+      auto count = packet_stats_collector_->GetDroppedPackets(category);
+      dropped_packets.AddMember(rapidjson::StringRef(kPacketCategoryNames[i]), count, allocator);
+      if (i != 0) {
+        dropped_packets_log += ' ';
+      }
+      dropped_packets_log += fmt::format("{}={}", kPacketCategoryNames[i], count);
+    }
+
+    MIRAKC_ARIB_SERVICE_RECORDER_INFO("PacketStats: Error: {}, Scrambled: {}, Dropped: {}",
+        error_packets, scrambled_packets, dropped_packets_log);
+
+    rapidjson::Value data(rapidjson::kObjectType);
+    data.AddMember("errorPackets", error_packets, allocator);
+    data.AddMember("scrambledPackets", scrambled_packets, allocator);
+    data.AddMember("droppedPackets", dropped_packets, allocator);
+
+    doc.AddMember("type", "packet-stats", allocator);
+    doc.AddMember("data", data, allocator);
+
+    FeedDocument(doc);
+    packet_stats_collector_->ResetPacketStats();
+  }
+
   void SendEventMessage(const std::string& type, const std::shared_ptr<ts::EIT>& eit,
       const ts::Time& time, uint64_t pos) {
     MIRAKC_ARIB_ASSERT(eit);
@@ -480,6 +545,7 @@ class ServiceRecorder final : public PacketSink,
   ts::PID pmt_pid_ = ts::PID_NULL;
   State state_ = State::kPreparing;
   bool event_started_ = false;
+  std::unique_ptr<PacketStatsCollector> packet_stats_collector_;
 
   friend class ServiceRecorderTestAccessor;
 

--- a/test/cli_tests.sh
+++ b/test/cli_tests.sh
@@ -89,6 +89,7 @@ assert 0 "$MIRAKC_ARIB filter-program-metadata --sid=0xFFFF"
 assert 0 "$MIRAKC_ARIB record-service --sid=1 --file=$TMPFILE --chunk-size=8192 --num-chunks=1"
 assert 0 "$MIRAKC_ARIB record-service --sid=1 --file=$TMPFILE --chunk-size=8192 --num-chunks=1 --start-pos=0"
 assert 0 "$MIRAKC_ARIB record-service --sid=1 --file=$TMPFILE --chunk-size=8192 --num-chunks=2 --start-pos=8192"
+assert 0 "$MIRAKC_ARIB record-service --sid=1 --file=$TMPFILE --chunk-size=8192 --num-chunks=2 --packet-stats"
 if [ -z "$CI" ]
 then
   # This test fails in GitHub Actions.

--- a/test/packet_stats_collector_test.cc
+++ b/test/packet_stats_collector_test.cc
@@ -1,0 +1,482 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// mirakc-arib
+// Copyright (C) 2019 masnagam
+//
+// This program is free software; you can redistribute it and/or modify it under the terms of the
+// GNU General Public License as published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+// the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program; if
+// not, write to the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston, MA
+// 02110-1301, USA.
+
+#include <cstring>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <tsduck/tsduck.h>
+
+#include "packet_stats_collector.hh"
+
+namespace {
+
+constexpr ts::PID kPid = 0x0100;
+
+ts::TSPacket MakePacket(
+    ts::PID pid, uint8_t cc, uint8_t data = 0xFF, bool tei = false, bool discontinuity = false) {
+  ts::TSPacket packet;
+  packet.init(pid, cc, data);
+  packet.setTEI(tei);
+  if (discontinuity) {
+    packet.setDiscontinuityIndicator(/*shift_payload=*/true);
+  }
+  return packet;
+}
+
+// Builds a packet containing only an adaptation field, i.e. hasPayload() == false.
+ts::TSPacket MakeNoPayloadPacket(ts::PID pid, uint8_t cc) {
+  ts::TSPacket packet;
+  packet.b[0] = 0x47;
+  packet.b[1] = static_cast<uint8_t>((pid >> 8) & 0x1F);
+  packet.b[2] = static_cast<uint8_t>(pid);
+  packet.b[3] = 0x20 | (cc & ts::CC_MASK);  // 0x20: adaptation field only, no payload
+  packet.b[4] = ts::PKT_SIZE - 5;           // Number of bytes after packet.b[4]
+  packet.b[5] = 0x00;  // 0x00: adaptation field flags (no discontinuity, no PCR, etc.)
+  ::memset(packet.b + 6, 0xFF, ts::PKT_SIZE - 6);
+  return packet;
+}
+
+// Configures kPid via the selected service's PMT so that its dropped packets are counted in the
+// kVideo category.
+void ConfigureVideoPid(PacketStatsCollector& collector) {
+  ts::PMT pmt;
+  pmt.streams.try_emplace(kPid, &pmt, ts::ST_MPEG2_VIDEO);
+  collector.UpdatePidCategories(pmt);
+}
+
+void ExpectNoDroppedPackets(const PacketStatsCollector& collector) {
+  for (size_t i = 0; i < kNumPacketCategories; ++i) {
+    EXPECT_EQ(0, collector.GetDroppedPackets(static_cast<PacketCategory>(i)));
+  }
+}
+
+}  // namespace
+
+// -----------------------------------------------------------------------------------------------
+// TEI / error-packet handling
+// -----------------------------------------------------------------------------------------------
+
+TEST(PacketStatsCollectorTest, TeiPacketIsCountedAsErrorAndExcludedFromContinuity) {
+  PacketStatsCollector collector;
+  ConfigureVideoPid(collector);
+  collector.CollectPacketStats(MakePacket(kPid, 0));
+  // A packet with TEI set may have a corrupted PID/CC, so it must not become the baseline for
+  // the next continuity check.
+  ts::TSPacket tei_packet = MakePacket(kPid, 5, 0xFF, /*tei=*/true);
+  tei_packet.setScrambling(1);
+  collector.CollectPacketStats(tei_packet);
+
+  EXPECT_EQ(1, collector.GetErrorPackets());
+  // The collector should not count a packet with TEI set as scrambled even if the scrambling bits
+  // happen to be set.
+  EXPECT_EQ(0, collector.GetScrambledPackets());
+
+  // The next regular packet must still be checked against the first packet's CC 0, not against
+  // the TEI packet's CC 5.
+  collector.CollectPacketStats(MakePacket(kPid, 1));
+  EXPECT_EQ(0, collector.GetDroppedPackets(PacketCategory::kVideo));
+}
+
+TEST(PacketStatsCollectorTest, TeiWithDiscontinuityIndicatorIsStillCountedAsError) {
+  PacketStatsCollector collector;
+  collector.CollectPacketStats(MakePacket(kPid, 0, 0xFF, /*tei=*/true, /*discontinuity=*/true));
+
+  EXPECT_EQ(1, collector.GetErrorPackets());
+}
+
+TEST(PacketStatsCollectorTest, TeiPacketIsCountedEvenWhenPidIsIgnored) {
+  PacketStatsCollector collector;
+  ts::TSPacket packet = MakePacket(kPid, 0, 0xFF, /*tei=*/true);
+  packet.setScrambling(1);
+  collector.CollectPacketStats(packet);
+
+  EXPECT_EQ(1, collector.GetErrorPackets());
+  EXPECT_EQ(0, collector.GetScrambledPackets());
+  ExpectNoDroppedPackets(collector);
+}
+
+// -----------------------------------------------------------------------------------------------
+// Scrambled-packet handling
+// -----------------------------------------------------------------------------------------------
+
+TEST(PacketStatsCollectorTest, ScrambledPacketIsCounted) {
+  PacketStatsCollector collector;
+  ConfigureVideoPid(collector);
+  ts::TSPacket packet = MakePacket(kPid, 0);
+  packet.setScrambling(1);
+  collector.CollectPacketStats(packet);
+
+  EXPECT_EQ(1, collector.GetScrambledPackets());
+}
+
+TEST(PacketStatsCollectorTest, ScrambledPacketIsCountedEvenWhenPidIsUnclassified) {
+  PacketStatsCollector collector;
+  ts::TSPacket packet = MakePacket(kPid, 0);
+  packet.setScrambling(1);
+  collector.CollectPacketStats(packet);
+
+  EXPECT_EQ(1, collector.GetScrambledPackets());
+}
+
+TEST(PacketStatsCollectorTest, ScrambledNullPacketIsNotCounted) {
+  PacketStatsCollector collector;
+  ts::TSPacket packet = MakePacket(ts::PID_NULL, 0);
+  packet.setScrambling(1);
+  collector.CollectPacketStats(packet);
+
+  EXPECT_EQ(0, collector.GetScrambledPackets());
+}
+
+// -----------------------------------------------------------------------------------------------
+// PID classification via PMT
+// -----------------------------------------------------------------------------------------------
+
+TEST(PacketStatsCollectorTest, PmtPidIsClassifiedAsPmt) {
+  constexpr ts::PID kPmtPid = 0x0030;
+  PacketStatsCollector collector;
+  collector.SetPmtPid(kPmtPid);
+  collector.CollectPacketStats(MakePacket(kPmtPid, 0));
+  collector.CollectPacketStats(MakePacket(kPmtPid, 5));
+
+  EXPECT_EQ(4, collector.GetDroppedPackets(PacketCategory::kPmt));
+}
+
+TEST(PacketStatsCollectorTest, UnclassifiedPidIsIgnored) {
+  PacketStatsCollector collector;
+  collector.CollectPacketStats(MakePacket(kPid, 0));
+  collector.CollectPacketStats(MakePacket(kPid, 5));
+
+  ExpectNoDroppedPackets(collector);
+}
+
+TEST(PacketStatsCollectorTest, PmtClassifiesStreamsByCategory) {
+  constexpr ts::PID kVideoPid = 0x0101;
+  constexpr ts::PID kAudioPid = 0x0102;
+  constexpr ts::PID kSubtitlePid = 0x0103;
+
+  ts::DuckContext context;
+  ts::PMT pmt;
+  pmt.streams.try_emplace(kVideoPid, &pmt, ts::ST_MPEG2_VIDEO);
+  pmt.streams.try_emplace(kAudioPid, &pmt, ts::ST_MPEG1_AUDIO);
+  pmt.streams.try_emplace(kSubtitlePid, &pmt, ts::ST_PES_PRIV);
+  pmt.streams[kSubtitlePid].descs.add(context, ts::StreamIdentifierDescriptor(0x30));
+
+  PacketStatsCollector collector;
+  collector.UpdatePidCategories(pmt);
+
+  collector.CollectPacketStats(MakePacket(kVideoPid, 0));
+  collector.CollectPacketStats(MakePacket(kVideoPid, 5));
+  EXPECT_EQ(4, collector.GetDroppedPackets(PacketCategory::kVideo));
+  collector.CollectPacketStats(MakePacket(kAudioPid, 0));
+  collector.CollectPacketStats(MakePacket(kAudioPid, 3));
+  EXPECT_EQ(2, collector.GetDroppedPackets(PacketCategory::kAudio));
+  collector.CollectPacketStats(MakePacket(kSubtitlePid, 0));
+  collector.CollectPacketStats(MakePacket(kSubtitlePid, 2));
+  EXPECT_EQ(1, collector.GetDroppedPackets(PacketCategory::kSubtitle));
+}
+
+TEST(PacketStatsCollectorTest, PmtPidCategoryIsNotUpdatedByInvalidPmt) {
+  constexpr ts::PID kPmtPid = 0x0100;
+
+  ts::PMT pmt;
+  // This invalid PMT references the selected service's PMT PID as its PCR and video stream.
+  pmt.pcr_pid = kPmtPid;
+  pmt.streams.try_emplace(kPmtPid, &pmt, ts::ST_MPEG2_VIDEO);
+
+  PacketStatsCollector collector;
+  collector.SetPmtPid(kPmtPid);
+  collector.UpdatePidCategories(pmt);
+
+  collector.CollectPacketStats(MakePacket(kPmtPid, 0));
+  collector.CollectPacketStats(MakePacket(kPmtPid, 5));
+
+  // The PMT PID must remain classified as PMT, not video, even when the invalid PMT specifies it
+  // as a video stream.
+  EXPECT_EQ(4, collector.GetDroppedPackets(PacketCategory::kPmt));
+  EXPECT_EQ(0, collector.GetDroppedPackets(PacketCategory::kVideo));
+}
+
+TEST(PacketStatsCollectorTest, PmtUpdateClassifiesPreviouslyIgnoredPid) {
+  PacketStatsCollector collector;
+
+  // This packet is not part of the selected service yet.
+  collector.CollectPacketStats(MakePacket(kPid, 0));
+
+  ts::PMT pmt;
+  pmt.streams.try_emplace(kPid, &pmt, ts::ST_MPEG2_VIDEO);
+  collector.UpdatePidCategories(pmt);
+
+  // The collector must not record CC 0 from the kPid packet received before kPid
+  // was classified as a video PID.
+  // Therefore, the next kPid packet with CC 2 must be treated as the first collected video
+  // packet, and must not add any dropped video packets.
+  collector.CollectPacketStats(MakePacket(kPid, 2));
+  EXPECT_EQ(0, collector.GetDroppedPackets(PacketCategory::kVideo));
+}
+
+TEST(PacketStatsCollectorTest, PmtUpdateResetsCategoryOfPidNoLongerReferenced) {
+  ts::PMT pmt;
+  pmt.streams.try_emplace(kPid, &pmt, ts::ST_MPEG2_VIDEO);
+
+  PacketStatsCollector collector;
+  collector.UpdatePidCategories(pmt);
+  collector.CollectPacketStats(MakePacket(kPid, 0));
+  collector.CollectPacketStats(MakePacket(kPid, 5));
+  EXPECT_EQ(4, collector.GetDroppedPackets(PacketCategory::kVideo));
+
+  // Because the new PMT no longer references kPid, subsequent kPid packets must be ignored.
+  ts::PMT next_pmt;
+  collector.UpdatePidCategories(next_pmt);
+  collector.CollectPacketStats(MakePacket(kPid, 6));
+  collector.CollectPacketStats(MakePacket(kPid, 9));
+  EXPECT_EQ(4, collector.GetDroppedPackets(PacketCategory::kVideo));
+}
+
+// -----------------------------------------------------------------------------------------------
+// PMT PID switching (SetPmtPid)
+// -----------------------------------------------------------------------------------------------
+
+TEST(PacketStatsCollectorTest, SetPmtPidResetsCategoryOfPreviousPmtPid) {
+  constexpr ts::PID kOldPmtPid = 0x0100;
+  constexpr ts::PID kNewPmtPid = 0x0200;
+
+  PacketStatsCollector collector;
+  collector.SetPmtPid(kOldPmtPid);
+  collector.SetPmtPid(kNewPmtPid);
+
+  // The old PMT PID is no longer part of the selected service and must be ignored.
+  collector.CollectPacketStats(MakePacket(kOldPmtPid, 0));
+  collector.CollectPacketStats(MakePacket(kOldPmtPid, 5));
+  ExpectNoDroppedPackets(collector);
+
+  collector.CollectPacketStats(MakePacket(kNewPmtPid, 0));
+  collector.CollectPacketStats(MakePacket(kNewPmtPid, 5));
+  EXPECT_EQ(4, collector.GetDroppedPackets(PacketCategory::kPmt));
+}
+
+TEST(PacketStatsCollectorTest, ChangingPmtPidKeepsStreamClassificationUntilNewPmt) {
+  constexpr ts::PID kNewPmtPid = 0x0200;
+
+  ts::PMT pmt;
+  pmt.streams.try_emplace(kPid, &pmt, ts::ST_MPEG2_VIDEO);
+
+  PacketStatsCollector collector;
+  collector.UpdatePidCategories(pmt);
+
+  // Simulate a PAT update that advertises kNewPmtPid as the PMT PID for the selected service.
+  // No PMT has arrived on kNewPmtPid yet.
+  collector.SetPmtPid(kNewPmtPid);
+
+  collector.CollectPacketStats(MakePacket(kPid, 0));
+  collector.CollectPacketStats(MakePacket(kPid, 5));
+
+  // Until a PMT arrives on kNewPmtPid, kPid must remain classified as video using the last PMT.
+  EXPECT_EQ(4, collector.GetDroppedPackets(PacketCategory::kVideo));
+}
+
+// -----------------------------------------------------------------------------------------------
+// PCR PID handling
+// -----------------------------------------------------------------------------------------------
+
+TEST(PacketStatsCollectorTest, PcrPidIsIgnored) {
+  constexpr ts::PID kVideoPid = 0x0101;
+  constexpr ts::PID kPcrPid = 0x0102;
+
+  ts::PMT pmt;
+  pmt.pcr_pid = kPcrPid;
+  pmt.streams.try_emplace(kVideoPid, &pmt, ts::ST_MPEG2_VIDEO);
+
+  PacketStatsCollector collector;
+  collector.UpdatePidCategories(pmt);
+
+  collector.CollectPacketStats(MakePacket(kPcrPid, 0));
+  collector.CollectPacketStats(MakePacket(kPcrPid, 5));
+
+  // A PCR-only PID, i.e. a PCR PID that is not referenced by any stream in the PMT, must not be
+  // classified into any category.
+  ExpectNoDroppedPackets(collector);
+}
+
+TEST(PacketStatsCollectorTest, PcrPidSharedWithVideoStreamIsClassifiedAsVideo) {
+  constexpr ts::PID kVideoPid = 0x0101;
+
+  ts::PMT pmt;
+  pmt.pcr_pid = kVideoPid;
+  pmt.streams.try_emplace(kVideoPid, &pmt, ts::ST_MPEG2_VIDEO);
+
+  PacketStatsCollector collector;
+  collector.UpdatePidCategories(pmt);
+
+  collector.CollectPacketStats(MakePacket(kVideoPid, 0));
+  collector.CollectPacketStats(MakePacket(kVideoPid, 5));
+  EXPECT_EQ(4, collector.GetDroppedPackets(PacketCategory::kVideo));
+}
+
+// -----------------------------------------------------------------------------------------------
+// NULL PID handling
+// -----------------------------------------------------------------------------------------------
+
+TEST(PacketStatsCollectorTest, NullPidInPmtIsIgnored) {
+  ts::PMT pmt;
+  // The collector must not track the NULL PID specified in any PMT field, because the NULL PID's
+  // CC is meaningless.
+  pmt.pcr_pid = ts::PID_NULL;
+  pmt.streams.try_emplace(ts::PID_NULL, &pmt, ts::ST_MPEG2_VIDEO);
+
+  PacketStatsCollector collector;
+  collector.UpdatePidCategories(pmt);
+
+  collector.CollectPacketStats(MakePacket(ts::PID_NULL, 0));
+  collector.CollectPacketStats(MakePacket(ts::PID_NULL, 5));
+
+  ExpectNoDroppedPackets(collector);
+}
+
+// -----------------------------------------------------------------------------------------------
+// Continuity counter / dropped-packet counting
+// -----------------------------------------------------------------------------------------------
+
+TEST(PacketStatsCollectorTest, RegularPacketsProduceZeroErrorStatistics) {
+  PacketStatsCollector collector;
+  ConfigureVideoPid(collector);
+  collector.CollectPacketStats(MakePacket(kPid, 0));
+  collector.CollectPacketStats(MakePacket(kPid, 1));
+  collector.CollectPacketStats(MakePacket(kPid, 2));
+
+  EXPECT_EQ(0, collector.GetErrorPackets());
+  EXPECT_EQ(0, collector.GetScrambledPackets());
+  ExpectNoDroppedPackets(collector);
+}
+
+TEST(PacketStatsCollectorTest, SameCcRecordsDroppedPackets) {
+  PacketStatsCollector collector;
+  ConfigureVideoPid(collector);
+  collector.CollectPacketStats(MakePacket(kPid, 0, 0xAA));
+  collector.CollectPacketStats(MakePacket(kPid, 0, 0xBB));
+
+  // A 0-to-0 CC transition must be counted as 15 dropped packets.
+  EXPECT_EQ(15, collector.GetDroppedPackets(PacketCategory::kVideo));
+}
+
+TEST(PacketStatsCollectorTest, MultipleMissingPacketsIncreasesDropped) {
+  PacketStatsCollector collector;
+  ConfigureVideoPid(collector);
+  collector.CollectPacketStats(MakePacket(kPid, 5));
+  collector.CollectPacketStats(MakePacket(kPid, 9));
+
+  EXPECT_EQ(3, collector.GetDroppedPackets(PacketCategory::kVideo));
+}
+
+TEST(PacketStatsCollectorTest, WrapAroundMissingPacketsIncreasesDropped) {
+  PacketStatsCollector collector;
+  ConfigureVideoPid(collector);
+  collector.CollectPacketStats(MakePacket(kPid, 14));
+  collector.CollectPacketStats(MakePacket(kPid, 2));
+
+  EXPECT_EQ(3, collector.GetDroppedPackets(PacketCategory::kVideo));
+}
+
+TEST(PacketStatsCollectorTest, NoPayloadSameCcDoesNotIncreaseDropped) {
+  PacketStatsCollector collector;
+  ConfigureVideoPid(collector);
+  collector.CollectPacketStats(MakeNoPayloadPacket(kPid, 3));
+  collector.CollectPacketStats(MakeNoPayloadPacket(kPid, 3));
+
+  EXPECT_EQ(0, collector.GetDroppedPackets(PacketCategory::kVideo));
+}
+
+TEST(PacketStatsCollectorTest, NoPayloadCcChangedIncreasesDropped) {
+  PacketStatsCollector collector;
+  ConfigureVideoPid(collector);
+  collector.CollectPacketStats(MakeNoPayloadPacket(kPid, 3));
+  collector.CollectPacketStats(MakeNoPayloadPacket(kPid, 4));
+
+  EXPECT_EQ(1, collector.GetDroppedPackets(PacketCategory::kVideo));
+}
+
+TEST(PacketStatsCollectorTest, DiscontinuityIndicatorDoesNotIncreaseDropped) {
+  PacketStatsCollector collector;
+  ConfigureVideoPid(collector);
+  collector.CollectPacketStats(MakePacket(kPid, 0));
+  collector.CollectPacketStats(MakePacket(kPid, 8, 0xFF, /*tei=*/false, /*discontinuity=*/true));
+
+  EXPECT_EQ(0, collector.GetDroppedPackets(PacketCategory::kVideo));
+}
+
+// -----------------------------------------------------------------------------------------------
+// CC state across PMT re-categorization
+// -----------------------------------------------------------------------------------------------
+
+TEST(PacketStatsCollectorTest, RecategorizedPidDropsItsCcState) {
+  PacketStatsCollector collector;
+  ConfigureVideoPid(collector);
+  collector.CollectPacketStats(MakePacket(kPid, 0));
+
+  // This PMT update leaves kPid uncategorized.  Packets received on kPid are ignored and do not
+  // update its CC state.
+  collector.UpdatePidCategories(ts::PMT());
+  collector.CollectPacketStats(MakePacket(kPid, 1));
+  collector.CollectPacketStats(MakePacket(kPid, 2));
+
+  // A later PMT update categorizes kPid again.  CC=3 must not be compared with the earlier CC=0.
+  ConfigureVideoPid(collector);
+  collector.CollectPacketStats(MakePacket(kPid, 3));
+  collector.CollectPacketStats(MakePacket(kPid, 4));
+
+  ExpectNoDroppedPackets(collector);
+}
+
+TEST(PacketStatsCollectorTest, RepeatedPmtKeepsCcState) {
+  PacketStatsCollector collector;
+  ConfigureVideoPid(collector);
+  collector.CollectPacketStats(MakePacket(kPid, 0));
+
+  // Processing the same PMT again must not reset CC state.
+  // The CC gap (0 to 2) must still be counted.
+  ConfigureVideoPid(collector);
+  collector.CollectPacketStats(MakePacket(kPid, 2));
+
+  EXPECT_EQ(1, collector.GetDroppedPackets(PacketCategory::kVideo));
+}
+
+// -----------------------------------------------------------------------------------------------
+// Reset behavior
+// -----------------------------------------------------------------------------------------------
+
+TEST(PacketStatsCollectorTest, ResetPacketStatsClearsAllCounters) {
+  PacketStatsCollector collector;
+  ConfigureVideoPid(collector);
+
+  collector.CollectPacketStats(MakePacket(kPid, 0));
+  collector.CollectPacketStats(MakePacket(kPid, 5));
+  ts::TSPacket tei_packet = MakePacket(kPid, 8, 0xFF, /*tei=*/true);
+  collector.CollectPacketStats(tei_packet);
+  ts::TSPacket scrambled_packet = MakePacket(kPid, 9);
+  scrambled_packet.setScrambling(1);
+  collector.CollectPacketStats(scrambled_packet);
+
+  EXPECT_EQ(1, collector.GetErrorPackets());
+  EXPECT_EQ(1, collector.GetScrambledPackets());
+  EXPECT_EQ(7, collector.GetDroppedPackets(PacketCategory::kVideo));
+
+  collector.ResetPacketStats();
+
+  EXPECT_EQ(0, collector.GetErrorPackets());
+  EXPECT_EQ(0, collector.GetScrambledPackets());
+  ExpectNoDroppedPackets(collector);
+}

--- a/test/service_recorder_test.cc
+++ b/test/service_recorder_test.cc
@@ -16,6 +16,8 @@
 // 02110-1301, USA.
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -41,6 +43,8 @@ class ServiceRecorderTestAccessor final {
     return recorder.clock_.IsReady();
   }
 };
+
+struct ServiceRecorderTest : testing::TestWithParam<ServiceRecorderOption> {};
 }  // namespace
 
 TEST(ServiceRecorderTest, NoPacket) {
@@ -191,8 +195,8 @@ TEST(ServiceRecorderTest, EventStart) {
   EXPECT_TRUE(src.IsEmpty());
 }
 
-TEST(ServiceRecorderTest, EventProgress) {
-  ServiceRecorderOption option = kOption;
+TEST_P(ServiceRecorderTest, EventProgress) {
+  ServiceRecorderOption option = GetParam();
 
   TableSource src;
   auto ring_sink = std::make_unique<MockRingSink>(option.chunk_size, option.num_chunks);
@@ -281,6 +285,20 @@ TEST(ServiceRecorderTest, EventProgress) {
           MockJsonlSink::Stringify(doc));
       return true;
     });
+    if (option.packet_stats) {
+      EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+        EXPECT_EQ(R"({"type":"packet-stats","data":{)"
+                  R"("errorPackets":0,)"
+                  R"("scrambledPackets":0,)"
+                  R"("droppedPackets":{)"
+                  R"("video":0,"audio":0,"subtitle":0,"pmt":0)"
+                  R"(})"
+                  R"(})"
+                  R"(})",
+            MockJsonlSink::Stringify(doc));
+        return true;
+      });
+    }
     EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
       EXPECT_EQ(R"({"type":"chunk","data":{"chunk":{)"
                 R"("timestamp":1609426800000,"pos":16384)"
@@ -308,6 +326,20 @@ TEST(ServiceRecorderTest, EventProgress) {
           MockJsonlSink::Stringify(doc));
       return true;
     });
+    if (option.packet_stats) {
+      EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+        EXPECT_EQ(R"({"type":"packet-stats","data":{)"
+                  R"("errorPackets":0,)"
+                  R"("scrambledPackets":0,)"
+                  R"("droppedPackets":{)"
+                  R"("video":0,"audio":0,"subtitle":0,"pmt":0)"
+                  R"(})"
+                  R"(})"
+                  R"(})",
+            MockJsonlSink::Stringify(doc));
+        return true;
+      });
+    }
     EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
       EXPECT_EQ(R"({"type":"chunk","data":{"chunk":{)"
                 R"("timestamp":1609426800000,"pos":0)"
@@ -315,6 +347,20 @@ TEST(ServiceRecorderTest, EventProgress) {
           MockJsonlSink::Stringify(doc));
       return true;
     });
+    if (option.packet_stats) {
+      EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+        EXPECT_EQ(R"({"type":"packet-stats","data":{)"
+                  R"("errorPackets":0,)"
+                  R"("scrambledPackets":0,)"
+                  R"("droppedPackets":{)"
+                  R"("video":0,"audio":0,"subtitle":0,"pmt":0)"
+                  R"(})"
+                  R"(})"
+                  R"(})",
+            MockJsonlSink::Stringify(doc));
+        return true;
+      });
+    }
     EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
       EXPECT_EQ(R"({"type":"stop","data":{"reset":false}})", MockJsonlSink::Stringify(doc));
       return true;
@@ -322,7 +368,7 @@ TEST(ServiceRecorderTest, EventProgress) {
     EXPECT_CALL(*ring_sink, End).WillOnce(testing::Return());
   }
 
-  auto recorder = std::make_unique<ServiceRecorder>(kOption);
+  auto recorder = std::make_unique<ServiceRecorder>(option);
   recorder->ServiceRecorder::Connect(std::move(ring_sink));
   recorder->JsonlSource::Connect(std::move(json_sink));
   src.Connect(std::move(recorder));
@@ -330,8 +376,8 @@ TEST(ServiceRecorderTest, EventProgress) {
   EXPECT_TRUE(src.IsEmpty());
 }
 
-TEST(ServiceRecorderTest, EventEnd) {
-  ServiceRecorderOption option = kOption;
+TEST_P(ServiceRecorderTest, EventEnd) {
+  ServiceRecorderOption option = GetParam();
 
   TableSource src;
   auto ring_sink = std::make_unique<MockRingSink>(option.chunk_size, option.num_chunks);
@@ -409,6 +455,21 @@ TEST(ServiceRecorderTest, EventEnd) {
           MockJsonlSink::Stringify(doc));
       return true;
     });
+    if (option.packet_stats) {
+      // Sent from HandleEventEnd().
+      EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+        EXPECT_EQ(R"({"type":"packet-stats","data":{)"
+                  R"("errorPackets":0,)"
+                  R"("scrambledPackets":0,)"
+                  R"("droppedPackets":{)"
+                  R"("video":0,"audio":0,"subtitle":0,"pmt":0)"
+                  R"(})"
+                  R"(})"
+                  R"(})",
+            MockJsonlSink::Stringify(doc));
+        return true;
+      });
+    }
     EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
       EXPECT_EQ(R"({"type":"event-end","data":{)"
                 R"("originalNetworkId":1,)"
@@ -449,6 +510,21 @@ TEST(ServiceRecorderTest, EventEnd) {
           MockJsonlSink::Stringify(doc));
       return true;
     });
+    if (option.packet_stats) {
+      // Sent from End().
+      EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
+        EXPECT_EQ(R"({"type":"packet-stats","data":{)"
+                  R"("errorPackets":0,)"
+                  R"("scrambledPackets":0,)"
+                  R"("droppedPackets":{)"
+                  R"("video":0,"audio":0,"subtitle":0,"pmt":0)"
+                  R"(})"
+                  R"(})"
+                  R"(})",
+            MockJsonlSink::Stringify(doc));
+        return true;
+      });
+    }
     EXPECT_CALL(*json_sink, HandleDocument).WillOnce([](const rapidjson::Document& doc) {
       EXPECT_EQ(R"({"type":"stop","data":{"reset":false}})", MockJsonlSink::Stringify(doc));
       return true;
@@ -456,12 +532,90 @@ TEST(ServiceRecorderTest, EventEnd) {
     EXPECT_CALL(*ring_sink, End).WillOnce(testing::Return());
   }
 
-  auto recorder = std::make_unique<ServiceRecorder>(kOption);
+  auto recorder = std::make_unique<ServiceRecorder>(option);
   recorder->ServiceRecorder::Connect(std::move(ring_sink));
   recorder->JsonlSource::Connect(std::move(json_sink));
   src.Connect(std::move(recorder));
   EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
   EXPECT_TRUE(src.IsEmpty());
+}
+
+// The `packet-stats` message sent before the `event-end` message must exclude the current TS
+// packet because `sink_->HandlePacket()` has not yet written the packet to the ring buffer.
+TEST(ServiceRecorderTest, EventEndDoesNotIncludeItsTriggeringPacketInPacketStats) {
+  ServiceRecorderOption option{"/dev/null", 3, kChunkSize, kNumChunks, 0, true};
+
+  TableSource src;
+  auto ring_sink = std::make_unique<MockRingSink>(option.chunk_size, option.num_chunks);
+  auto json_sink = std::make_unique<MockJsonlSink>();
+
+  src.LoadXml(R"(
+    <?xml version="1.0" encoding="utf-8"?>
+    <tsduck>
+      <PAT version="1" current="true" transport_stream_id="0x0002"
+           test-pid="0x0000">
+        <service service_id="0x0003" program_map_PID="0x0101" />
+      </PAT>
+      <PMT version="1" current="true" service_id="0x0003" PCR_PID="0x901"
+           test-pid="0x0101">
+        <component elementary_PID="0x0901" stream_type="0x02" />
+      </PMT>
+      <TOT UTC_time="2021-01-01 00:00:00" test-pid="0x0014" />
+      <!-- This PCR packet makes the clock ready with the preceding TOT. -->
+      <generic_short_table table_id="0xFF" test-pid="0x0901" test-pcr="0" />
+      <EIT type="pf" version="1" current="true" actual="true"
+           service_id="0x0003" transport_stream_id="0x0002"
+           original_network_id="0x0001" last_table_id="0x4E"
+           test-pid="0x0012">
+        <event event_id="4" start_time="2021-01-01 00:00:00"
+               duration="00:00:01" running_status="undefined" CA_mode="true" />
+      </EIT>
+      <!-- This PCR packet establishes the CC baseline after recording starts. -->
+      <generic_short_table table_id="0xFF" test-pid="0x0901" test-pcr="1" test-cc="0" />
+      <!-- This PCR value advances the clock to event#4's end time.  CC 5 causes the recorder to
+           record four dropped `video` packets. -->
+      <generic_short_table table_id="0xFF" test-pid="0x0901" test-pcr="27000000" test-cc="5" />
+    </tsduck>
+  )");
+
+  std::vector<std::string> message_types;
+  std::vector<uint64_t> dropped_video_packet_counts;
+  EXPECT_CALL(*json_sink, HandleDocument)
+      .WillRepeatedly(
+          [&message_types, &dropped_video_packet_counts](const rapidjson::Document& doc) {
+            const std::string type = doc["type"].GetString();
+
+            // Accept every message, but record only `packet-stats` and `event-end` messages
+            // to verify their order and dropped-packet counts later with EXPECT_THAT calls.
+            if (type == "packet-stats") {
+              message_types.emplace_back(type);
+              dropped_video_packet_counts.emplace_back(
+                  doc["data"]["droppedPackets"]["video"].GetUint64());
+            } else if (type == "event-end") {
+              message_types.emplace_back(type);
+            }
+
+            return true;
+          });
+
+  {
+    testing::InSequence seq;
+    EXPECT_CALL(*ring_sink, Start).WillOnce(testing::Return(true));
+    EXPECT_CALL(*ring_sink, End).WillOnce(testing::Return());
+  }
+
+  auto recorder = std::make_unique<ServiceRecorder>(option);
+  recorder->ServiceRecorder::Connect(std::move(ring_sink));
+  recorder->JsonlSource::Connect(std::move(json_sink));
+  src.Connect(std::move(recorder));
+
+  EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
+  EXPECT_TRUE(src.IsEmpty());
+  EXPECT_THAT(message_types, testing::ElementsAre("packet-stats", "event-end", "packet-stats"));
+
+  // The first `packet-stats` message must report zero dropped `video` packets because the final
+  // PCR packet has not been written to the ring buffer yet.
+  EXPECT_THAT(dropped_video_packet_counts, testing::ElementsAre(0, 4));
 }
 
 TEST(ServiceRecorderTest, EventStartBeforeEventEnd) {
@@ -991,3 +1145,7 @@ TEST(ServiceRecorderTest, EndOfChunkBeforeNextEvent) {
   EXPECT_EQ(EXIT_SUCCESS, src.FeedPackets());
   EXPECT_TRUE(src.IsEmpty());
 }
+
+INSTANTIATE_TEST_SUITE_P(EventTestWithPacketStats, ServiceRecorderTest,
+    testing::Values(ServiceRecorderOption{"/dev/null", 3, kChunkSize, kNumChunks, 0, false},
+        ServiceRecorderOption{"/dev/null", 3, kChunkSize, kNumChunks, 0, true}));


### PR DESCRIPTION
## 概要

#77 の、`mirakc-arib record-service`におけるpacket statsを再実装しました。
旧実装では全PIDのcontinuity counter（CC）を単一のカウンターで集計していましたが、映像・音声・字幕などのカテゴリ別にドロップ数を集計するように変更しました。

[#77 のレビューコメント](https://github.com/mirakc/mirakc-arib/pull/77#discussion_r1228973468)でmasnagamさんが指摘したとおり、
PSI/SIは再送される一方でPESのドロップは映像・音声の乱れに直結するなど、パケットの種類によってドロップの影響が異なるのが理由です。
ドロップ数は以下のカテゴリ別で集計します。

- 映像
- 音声
- 字幕（ARIB字幕・文字スーパーの両方）
- 選択したサービスのPMT

ドロップ数だけでなく、`ServiceFilter`通過後の全TSパケットについて
TEI（`transport_error_indicator`）付きのパケット数とスクランブル化されたままのパケット数も集計します。

### `stop`メッセージのヘルプ文言も修正

実際には`record-service`での録画終了時は`stop`メッセージが送られるのに、
ヘルプ文言では`end`と表記されているのも同時に修正しています。

## 実装詳細

`record-service`に新オプション`--packet-stats`を追加しました。
指定時は、次の形式の`packet-stats`メッセージを送信します。

```json
{
  "type": "packet-stats",
  "data": {
    "errorPackets": 0,
    "scrambledPackets": 0,
    "droppedPackets": {
      "video": 0,
      "audio": 0,
      "subtitle": 0,
      "pmt": 0
    }
  }
}
```

- `errorPackets`: TEI付きのパケット数
- `scrambledPackets`: TSCが0以外のパケット数（NULL PIDとTEI付きパケットは除外）
- `droppedPackets`: 不連続のCCから推定したカテゴリ別のドロップ数

`packet-stats`メッセージは、各`chunk`、`event-end`、`stop`メッセージの直前に送信します。
ただし録画開始直後に送信される最初の`chunk`メッセージの直前で`packet-stats`メッセージの送信を行う事はしません。
集計は録画開始後に記録されたパケットのみが対象で、録画開始直後はまだ1パケットも集計されていないからです。

各カウンターは0から開始し、`packet-stats`メッセージの送信ごとにリセットされます。
各メッセージの値は、前回の`packet-stats`（初回は録画開始）からの区間の集計値です。

## 集計上の制約

### ServiceFilterで除外されるパケット

`ServiceFilter`の後段に来る`ServiceRecorder`で集計を行うため、`ServiceFilter`で除外されたパケットは`errorPackets`と`scrambledPackets`に含まれません。

稀なケースかも知れませんが、現在`ServiceFilter`はTEI付きパケットを特別扱いしていないので、
エラーにより`ServiceFilter`の段階でPIDが既に化けていた場合は過剰（または過小）に`errorPackets`が計上される可能性もあります。

### 16パケット以上の連続ドロップ

CCは4bitのため、ドロップ数は`(CC - 期待値) & 0x0F`で推定しており、正しく数えられるのは15パケットまでです。
16パケット以上が連続してドロップした場合は16で割った余りが計上され、ちょうど16の倍数であればドロップなしと見なされます。

### 重複パケット

#77 の旧実装は前パケットとの比較で重複を検出していましたが、今回はそれをやめました。
MPEG-2 TSは同一パケットの2回送出を規格上は許していますが、日本のデジタル放送で重複パケットが送られたという報告は見つからず、対応する価値が低いと判断したためです。
前パケットを保持していないため、重複とドロップが区別できず、仮にペイロードを持つ重複パケットが送られた場合は15パケットのドロップとして計上されます。

### PAT PID

`ServiceFilter`はPATを書き換えてから`ServiceRecorder`に渡します。
この際CCは必ず連続している状態になるため、入力TSにおけるPATのドロップは追跡できません。

### PCR PID

映像PIDなどと共有されないPCR専用PIDは、ペイロードがなくCCが増加しないため、CCからドロップ数を推定できません。

映像PIDなどとPCR PIDが共有される場合は、そのカテゴリとしての追跡はされますが、
私の手持ちのARIB MPEG2-TSはPCR専用PIDしか使用していませんでした。
「映像PIDなどとPCR PIDが共有されていた」というネット上での報告も私が探した限りは無かったです。

## テスト

### 実ストリームでの確認方法

指定したカテゴリのパケットを実際にドロップさせて、対応するカウンターが増えることを確認できます。
ちょうど良いツールが見当たらなかったため、標準入力のTSの一部パケットをドロップしたり、TEIやスクランブルを付けたりする[ts-corrupt](https://github.com/vroad/ts-corrupt)をAIで作成しました。
`ts-pids.py`が`tsresync`と`tstables`を使うため、TSDuckが必要です。

`ts-pids.py`はPMTを読んでカテゴリに対応するPIDを`--pid`引数の形で出力し、`ts-corrupt.py`がそのPIDのパケットの一部をドロップします。

実行コマンドの例を以下で示します。
mirakc-aribは`~/Git/mirakc-arib/`でビルドしていて、ts-corruptは`~/Git/ts-corrupt`にあり、mirakcは`http://ts262:40772`で動作している前提です。

```bash
export PATH=$PATH:~/Git/mirakc-arib/build/bin/:~/Git/ts-corrupt/
url='http://ts262:40772/api/channels/GR/22/stream?decode=1'
sid=43008

dir=$(mktemp -d)
file="$dir/ring.m2ts"
pids=$(ts-pids.py -u "$url" -s $sid -c video)
echo "file: $file"
echo "pids: $pids"

curl -sN "$url" \
  | ts-corrupt.py --rate 0.001 --burst 4 $pids \
  | mirakc-arib record-service --sid=$sid --file="$file" \
      --chunk-size=$((8192 * 1024)) --num-chunks=8 --packet-stats \
  | jq -c
```

`ts-pids.py`の`-c`に渡すカテゴリを変えると、増加する`droppedPackets`のカウンターも変わります。
`video`・`audio`・`subtitle`・`pmt`は`droppedPackets`の同名フィールドに対応します。

`other`はPMTに列挙された残りのPID（PCR専用PIDなど）で、カテゴリの分類対象外のため`droppedPackets`のどのカウンターも増えません。
分類対象外のPIDでのドロップが、誤って他のカテゴリに計上されていないかの確認に使えます。

`ts-corrupt.py`に`--tei`を付けると、パケットをドロップする代わりにTEIを立てるため`errorPackets`が増えます。
`--scramble`を付けた場合はTSCにeven key（`10`）を設定するため`scrambledPackets`が増えます。

### テスト一覧

AIを使用し、テスト一覧と、テストの意図を示す日本語での簡潔な説明文を生成しました。
（テスト名だけですぐ意図分かりそうな簡単な内容のテストもありますが、全部に対し説明文を生成しました）

<details>
<summary><code>PacketStatsCollector</code>のテスト一覧</summary>

### TEI

| テスト | 内容 |
|---|---|
| [`TeiPacketIsCountedAsErrorAndExcludedFromContinuity`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L74) | TEI付きパケットをエラーに計上し、CCとスクランブルの判定から除外 |
| [`TeiWithDiscontinuityIndicatorIsStillCountedAsError`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L95) | discontinuity indicatorがあってもTEIを計上 |
| [`TeiPacketIsCountedEvenWhenPidIsIgnored`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L102) | 未分類PIDのTEIも計上 |

### スクランブル

| テスト | 内容 |
|---|---|
| [`ScrambledPacketIsCounted`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L117) | スクランブルされたパケットを計上 |
| [`ScrambledPacketIsCountedEvenWhenPidIsUnclassified`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L127) | 未分類PIDのスクランブルも計上 |
| [`ScrambledNullPacketIsNotCounted`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L136) | NULL PIDのスクランブルは除外 |

### PIDの分類

| テスト | 内容 |
|---|---|
| [`PmtPidIsClassifiedAsPmt`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L149) | PMT PIDを`pmt`に分類 |
| [`UnclassifiedPidIsIgnored`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L159) | 未分類PIDをドロップ数の集計から除外 |
| [`PmtClassifiesStreamsByCategory`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L167) | PMTの内容から映像・音声・字幕に分類 |
| [`PmtPidCategoryIsNotUpdatedByInvalidPmt`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L193) | PMT PIDを映像ストリームとして列挙する不正なPMTがPMT PIDのカテゴリを上書きしない |
| [`PmtUpdateClassifiesPreviouslyIgnoredPid`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L214) | PMT更新前の未分類PIDのCCを引き継がない |
| [`PmtUpdateResetsCategoryOfPidNoLongerReferenced`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L232) | PMTから外れたPIDを追跡対象から除外 |

### PMT PIDの変更

| テスト | 内容 |
|---|---|
| [`SetPmtPidResetsCategoryOfPreviousPmtPid`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L254) | 変更前のPMT PIDを追跡対象から除外 |
| [`ChangingPmtPidKeepsStreamClassificationUntilNewPmt`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L272) | 新しいPMTの受信までは既存のストリーム分類を維持 |

### PCR PIDとNULL PID

| テスト | 内容 |
|---|---|
| [`PcrPidIsIgnored`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L296) | PCR専用PIDを追跡しない |
| [`PcrPidSharedWithVideoStreamIsClassifiedAsVideo`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L315) | 映像と共有されるPCR PIDを映像に分類 |
| [`NullPidInPmtIsIgnored`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L334) | PMTに含まれるNULL PIDを追跡しない |

### CCとドロップ数

| テスト | 内容 |
|---|---|
| [`RegularPacketsProduceZeroErrorStatistics`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L354) | 正常な連番パケットでは全カウンターが0 |
| [`SameCcRecordsDroppedPackets`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L366) | ペイロードありでCCが変化しない場合は15パケットのドロップとして計上 |
| [`MultipleMissingPacketsIncreasesDropped`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L376) | 複数パケットドロップ時の計算 |
| [`WrapAroundMissingPacketsIncreasesDropped`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L385) | CCのラップアラウンドを含むドロップ数の計算 |
| [`NoPayloadSameCcDoesNotIncreaseDropped`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L394) | ペイロードなし・CC不変はドロップとして計上しない |
| [`NoPayloadCcChangedIncreasesDropped`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L403) | ペイロードなし・CC変化はドロップとして計上 |
| [`DiscontinuityIndicatorDoesNotIncreaseDropped`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L412) | discontinuity indicatorがある場合はドロップとして計上しない |

### PMT更新時のCC状態

| テスト | 内容 |
|---|---|
| [`RecategorizedPidDropsItsCcState`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L425) | 追跡対象から外れたPIDのCC状態を破棄 |
| [`RepeatedPmtKeepsCcState`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L444) | 同一PMTの再受信ではCC状態を維持 |

### リセット

| テスト | 内容 |
|---|---|
| [`ResetPacketStatsClearsAllCounters`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/packet_stats_collector_test.cc#L461) | 全集計カウンターをリセット |
</details>

<details>
<summary><code>ServiceRecorder</code>のテスト</summary>

- [`EventProgress`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/service_recorder_test.cc#L198): `--packet-stats`の有無による`chunk` / `stop`前の`packet-stats`メッセージ送信と、最初の`chunk`の前では送信しないことを確認
- [`EventEnd`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/service_recorder_test.cc#L379): `event-end` / `stop`前の`packet-stats`メッセージ送信を確認
- [`EventEndDoesNotIncludeItsTriggeringPacketInPacketStats`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/service_recorder_test.cc#L545): `event-end`を発生させた未書き込みパケットが直前の`packet-stats`の集計に含まれないことを確認

</details>

<details>
<summary>CLIのテスト</summary>

- [`cli_tests.sh`](https://github.com/mirakc/mirakc-arib/blob/4cbee39/test/cli_tests.sh#L92): `record-service`が`--packet-stats`を受け付け、空の標準入力に対して終了コード0で終了することを確認

</details>
